### PR TITLE
refactor(lib): extract parseFilters, formatRelative, vote-reducer

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -3,49 +3,15 @@ import { Hero } from "@/components/sections/hero";
 import { FilterBar } from "@/components/sections/filter-bar";
 import { CityGrid } from "@/components/sections/city-grid";
 import { Footer } from "@/components/sections/footer";
-import { getCities, type CityFilters } from "@/lib/queries";
+import { getCities } from "@/lib/queries";
 import { createClient } from "@/utils/supabase/server";
 import { getNavbarUser } from "@/lib/current-user";
-import type { AreaRegion, BudgetBand } from "@/lib/database.types";
-
-const BUDGETS: BudgetBand[] = ["100만원 이하", "100~200만원", "200만원 이상"];
-const AREAS: AreaRegion[] = [
-  "수도권",
-  "경상도",
-  "전라도",
-  "강원도",
-  "제주도",
-  "충청도",
-];
-
-type HomeSearchParams = Promise<{
-  budget?: string;
-  region?: string;
-  environment?: string;
-  bestSeason?: string;
-}>;
-
-function parseFilters(params: Awaited<HomeSearchParams>): CityFilters {
-  const filters: CityFilters = {};
-  if (params.budget && BUDGETS.includes(params.budget as BudgetBand)) {
-    filters.budget = params.budget as BudgetBand;
-  }
-  if (params.region && AREAS.includes(params.region as AreaRegion)) {
-    filters.area = params.region as AreaRegion;
-  }
-  if (params.environment && params.environment !== "all") {
-    filters.environment = params.environment;
-  }
-  if (params.bestSeason && params.bestSeason !== "all") {
-    filters.bestSeason = params.bestSeason;
-  }
-  return filters;
-}
+import { parseFilters, type HomeSearchParams } from "@/lib/filters";
 
 export default async function Home({
   searchParams,
 }: {
-  searchParams: HomeSearchParams;
+  searchParams: Promise<HomeSearchParams>;
 }) {
   const params = await searchParams;
   const filters = parseFilters(params);

--- a/app/src/components/sections/city-card.tsx
+++ b/app/src/components/sections/city-card.tsx
@@ -4,12 +4,7 @@ import { useOptimistic, useTransition } from "react";
 import Link from "next/link";
 import type { CityWithWeather } from "@/lib/database.types";
 import { voteCity, type VoteDirection } from "@/app/actions/city-vote";
-
-type VoteState = {
-  vote: "none" | "like" | "dislike";
-  likeCount: number;
-  dislikeCount: number;
-};
+import { voteReducer, type VoteState } from "@/lib/vote-reducer";
 
 export function CityCard({
   city,
@@ -28,33 +23,7 @@ export function CityCard({
       likeCount: city.like_count,
       dislikeCount: city.dislike_count,
     },
-    (prev, action) => {
-      const next: VoteState = { ...prev };
-      if (action === "clear") {
-        if (prev.vote === "like") next.likeCount -= 1;
-        if (prev.vote === "dislike") next.dislikeCount -= 1;
-        next.vote = "none";
-      } else if (action === "like") {
-        if (prev.vote === "like") {
-          next.likeCount -= 1;
-          next.vote = "none";
-        } else {
-          if (prev.vote === "dislike") next.dislikeCount -= 1;
-          next.likeCount += 1;
-          next.vote = "like";
-        }
-      } else if (action === "dislike") {
-        if (prev.vote === "dislike") {
-          next.dislikeCount -= 1;
-          next.vote = "none";
-        } else {
-          if (prev.vote === "like") next.likeCount -= 1;
-          next.dislikeCount += 1;
-          next.vote = "dislike";
-        }
-      }
-      return next;
-    }
+    voteReducer
   );
 
   function send(direction: VoteDirection, serverDirection: VoteDirection) {

--- a/app/src/components/sections/city-detail-reviews.tsx
+++ b/app/src/components/sections/city-detail-reviews.tsx
@@ -1,19 +1,8 @@
 import { getReviewsByCity } from "@/lib/queries";
+import { formatRelative } from "@/lib/format";
 
 interface CityDetailReviewsProps {
   cityId: string;
-}
-
-function formatRelative(iso: string) {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const day = 24 * 60 * 60 * 1000;
-  if (diffMs < day) return "오늘";
-  const days = Math.floor(diffMs / day);
-  if (days < 7) return `${days}일 전`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}주 전`;
-  const months = Math.floor(days / 30);
-  return months < 12 ? `${months}개월 전` : `${Math.floor(days / 365)}년 전`;
 }
 
 export async function CityDetailReviews({ cityId }: CityDetailReviewsProps) {

--- a/app/src/components/sections/recent-reviews.tsx
+++ b/app/src/components/sections/recent-reviews.tsx
@@ -2,6 +2,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getRecentReviews } from "@/lib/queries";
+import { formatRelative } from "@/lib/format";
 
 function StarRating({ rating }: { rating: number }) {
   return (
@@ -10,17 +11,6 @@ function StarRating({ rating }: { rating: number }) {
       {rating % 1 >= 0.5 ? "⭐" : ""}
     </span>
   );
-}
-
-function formatRelative(iso: string) {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const day = 24 * 60 * 60 * 1000;
-  if (diffMs < day) return "오늘";
-  const days = Math.floor(diffMs / day);
-  if (days < 7) return `${days}일 전`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}주 전`;
-  return `${Math.floor(days / 30)}개월 전`;
 }
 
 export async function RecentReviews() {

--- a/app/src/lib/filters.ts
+++ b/app/src/lib/filters.ts
@@ -1,0 +1,41 @@
+import type { AreaRegion, BudgetBand } from "@/lib/database.types";
+import type { CityFilters } from "@/lib/queries";
+
+export const BUDGETS: BudgetBand[] = [
+  "100만원 이하",
+  "100~200만원",
+  "200만원 이상",
+];
+
+export const AREAS: AreaRegion[] = [
+  "수도권",
+  "경상도",
+  "전라도",
+  "강원도",
+  "제주도",
+  "충청도",
+];
+
+export interface HomeSearchParams {
+  budget?: string;
+  region?: string;
+  environment?: string;
+  bestSeason?: string;
+}
+
+export function parseFilters(params: HomeSearchParams): CityFilters {
+  const filters: CityFilters = {};
+  if (params.budget && BUDGETS.includes(params.budget as BudgetBand)) {
+    filters.budget = params.budget as BudgetBand;
+  }
+  if (params.region && AREAS.includes(params.region as AreaRegion)) {
+    filters.area = params.region as AreaRegion;
+  }
+  if (params.environment && params.environment !== "all") {
+    filters.environment = params.environment;
+  }
+  if (params.bestSeason && params.bestSeason !== "all") {
+    filters.bestSeason = params.bestSeason;
+  }
+  return filters;
+}

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -1,0 +1,13 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function formatRelative(iso: string, now: number = Date.now()): string {
+  const diffMs = now - new Date(iso).getTime();
+  if (diffMs < DAY_MS) return "오늘";
+  const days = Math.floor(diffMs / DAY_MS);
+  if (days < 7) return `${days}일 전`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}주 전`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}개월 전`;
+  return `${Math.floor(days / 365)}년 전`;
+}

--- a/app/src/lib/vote-reducer.ts
+++ b/app/src/lib/vote-reducer.ts
@@ -1,0 +1,40 @@
+import type { VoteDirection } from "@/app/actions/city-vote";
+
+export type VoteValue = "none" | "like" | "dislike";
+
+export interface VoteState {
+  vote: VoteValue;
+  likeCount: number;
+  dislikeCount: number;
+}
+
+export function voteReducer(
+  prev: VoteState,
+  action: VoteDirection
+): VoteState {
+  const next: VoteState = { ...prev };
+  if (action === "clear") {
+    if (prev.vote === "like") next.likeCount -= 1;
+    if (prev.vote === "dislike") next.dislikeCount -= 1;
+    next.vote = "none";
+  } else if (action === "like") {
+    if (prev.vote === "like") {
+      next.likeCount -= 1;
+      next.vote = "none";
+    } else {
+      if (prev.vote === "dislike") next.dislikeCount -= 1;
+      next.likeCount += 1;
+      next.vote = "like";
+    }
+  } else if (action === "dislike") {
+    if (prev.vote === "dislike") {
+      next.dislikeCount -= 1;
+      next.vote = "none";
+    } else {
+      if (prev.vote === "like") next.likeCount -= 1;
+      next.dislikeCount += 1;
+      next.vote = "dislike";
+    }
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
- Move three pure helpers out of their components so they can be imported by Vitest specs without rendering React or awaiting server components:
  - `lib/filters.ts` — `parseFilters`, `BUDGETS`, `AREAS`, and `HomeSearchParams` (was inline in `app/page.tsx`).
  - `lib/format.ts` — `formatRelative(iso, now?)` consolidating the duplicate that lived in `city-detail-reviews.tsx` and `recent-reviews.tsx`. The detail-page version (which falls through to years) is now used everywhere; the recent-reviews copy previously capped at "개월 전" for anything over ~5 weeks.
  - `lib/vote-reducer.ts` — `VoteState`, `VoteValue`, and `voteReducer` extracted from the inline `useOptimistic` callback in `city-card.tsx`.

## Motivation
This is the prep step for the upcoming test PR: each of these helpers now lives in its own file with no React or Supabase dependency, so the Vitest spec files can test them directly.

## Behavior change
None, with one exception: `recent-reviews.tsx` previously rendered anything older than ~5 weeks as "N개월 전", including values >12 months. After this PR it falls through to "N년 전" the same way `city-detail-reviews.tsx` already did. This is a strict superset of the old behavior.

## Validation
- `npx tsc --noEmit`: clean
- `npx next build`: clean

## Test plan
- [ ] Home page still renders and filters still apply via URL search params (uses `parseFilters`).
- [ ] City detail page and recent reviews widget render dates in the expected Korean relative form.
- [ ] City card 👍/👎 toggle still behaves optimistically (uses `voteReducer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)