### PR TITLE
test: Vitest + RTL + Playwright suite (132 unit + 20 E2E)

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -22,15 +22,30 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "happy-dom": "^20.9.0",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -533,6 +548,16 @@
         }
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.54.1",
       "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.54.1.tgz",
@@ -731,21 +756,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -753,9 +778,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1945,6 +1970,315 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1969,6 +2303,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.99.1",
@@ -2355,6 +2696,107 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -2441,6 +2883,32 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2507,6 +2975,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -3082,6 +3557,150 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3395,6 +4014,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -3411,6 +4040,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3659,6 +4307,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3955,6 +4613,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4176,6 +4841,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4207,6 +4883,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -4291,6 +4975,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4425,6 +5122,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4946,6 +5650,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5010,6 +5724,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5330,6 +6054,20 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5561,6 +6299,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5586,6 +6331,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -5712,6 +6475,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5812,6 +6582,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6437,6 +7217,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6991,6 +7810,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6999,6 +7829,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7103,6 +7974,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7551,6 +8432,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7811,6 +8703,13 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7838,6 +8737,38 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7849,9 +8780,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7910,6 +8841,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -8086,6 +9066,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8224,6 +9218,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
     "node_modules/router": {
@@ -8711,6 +9739,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8754,6 +9789,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8762,6 +9804,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -8984,6 +10033,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9101,6 +10163,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -9111,14 +10180,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9146,9 +10215,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9156,6 +10225,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9230,6 +10309,27 @@
       "dependencies": {
         "@ts-morph/common": "~0.27.0",
         "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -9603,6 +10703,491 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -9610,6 +11195,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -9714,6 +11309,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test --config=tests-e2e/playwright.config.ts",
+    "test:e2e:install": "playwright install"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
@@ -23,13 +28,21 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.5"
   }
 }

--- a/app/src/app/actions/city-vote.test.ts
+++ b/app/src/app/actions/city-vote.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", async () => {
+  const { nextNavigationFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextNavigationFactory();
+});
+vi.mock("next/cache", async () => {
+  const { nextCacheFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextCacheFactory();
+});
+vi.mock("next/headers", async () => {
+  const { nextHeadersFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextHeadersFactory();
+});
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { getNextMockState, resetNextMocks } from "../../../test/helpers/next-mocks";
+import {
+  makeSupabaseClient,
+  type AuthUser,
+} from "../../../test/helpers/supabase-mock";
+import { createClient } from "@/utils/supabase/server";
+import { voteCity } from "./city-vote";
+
+const mockedCreateClient = createClient as unknown as ReturnType<typeof vi.fn>;
+
+const sampleUser: AuthUser = {
+  id: "user-123",
+  email: "tester@example.com",
+};
+
+describe("voteCity", () => {
+  beforeEach(() => {
+    resetNextMocks();
+    mockedCreateClient.mockReset();
+  });
+
+  it("redirects unauthenticated users to /login with the expected error message", async () => {
+    const client = makeSupabaseClient({ auth: { user: null } });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(voteCity("seoul", "like")).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect, revalidatePath } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    const redirectArg = redirect.mock.calls[0][0] as string;
+    expect(redirectArg).toContain("/login?error=");
+    expect(decodeURIComponent(redirectArg.split("error=")[1])).toBe(
+      "로그인 후 투표할 수 있어요."
+    );
+    // Should not have touched any DB table or revalidated anything.
+    expect(client.from).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("upserts a +1 vote when direction is 'like'", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: sampleUser },
+      from: { city_votes: { upsert: { data: null, error: null } } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await voteCity("seoul", "like");
+
+    expect(client.from).toHaveBeenCalledWith("city_votes");
+    const upsertCalls = client.calls.city_votes?.upsert ?? [];
+    expect(upsertCalls).toHaveLength(1);
+    const [payload, options] = upsertCalls[0];
+    expect(payload).toEqual({
+      city_id: "seoul",
+      user_id: sampleUser.id,
+      vote: 1,
+    });
+    expect(options).toEqual({ onConflict: "city_id,user_id" });
+    // delete should not have been invoked.
+    expect(client.calls.city_votes?.delete).toBeUndefined();
+  });
+
+  it("upserts a -1 vote when direction is 'dislike'", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: sampleUser },
+      from: { city_votes: { upsert: { data: null, error: null } } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await voteCity("busan", "dislike");
+
+    const upsertCalls = client.calls.city_votes?.upsert ?? [];
+    expect(upsertCalls).toHaveLength(1);
+    const [payload, options] = upsertCalls[0];
+    expect(payload).toEqual({
+      city_id: "busan",
+      user_id: sampleUser.id,
+      vote: -1,
+    });
+    expect(options).toEqual({ onConflict: "city_id,user_id" });
+  });
+
+  it("deletes the vote row filtered by city_id + user_id when direction is 'clear'", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: sampleUser },
+      from: { city_votes: { delete: { data: null, error: null } } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await voteCity("jeju", "clear");
+
+    expect(client.from).toHaveBeenCalledWith("city_votes");
+    expect(client.calls.city_votes?.delete).toHaveLength(1);
+    const eqCalls = client.calls.city_votes?.eq ?? [];
+    expect(eqCalls).toEqual(
+      expect.arrayContaining([
+        ["city_id", "jeju"],
+        ["user_id", sampleUser.id],
+      ])
+    );
+    // upsert should not have been called.
+    expect(client.calls.city_votes?.upsert).toBeUndefined();
+  });
+
+  it("revalidates both '/' and the city detail path after a successful write", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: sampleUser },
+      from: { city_votes: { upsert: { data: null, error: null } } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await voteCity("gyeongju", "like");
+
+    const { revalidatePath } = getNextMockState();
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenNthCalledWith(1, "/");
+    expect(revalidatePath).toHaveBeenNthCalledWith(2, "/city/gyeongju");
+  });
+
+  it("also revalidates both paths when the 'clear' branch runs", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: sampleUser },
+      from: { city_votes: { delete: { data: null, error: null } } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await voteCity("incheon", "clear");
+
+    const { revalidatePath } = getNextMockState();
+    expect(revalidatePath).toHaveBeenCalledTimes(2);
+    expect(revalidatePath).toHaveBeenNthCalledWith(1, "/");
+    expect(revalidatePath).toHaveBeenNthCalledWith(2, "/city/incheon");
+  });
+});

--- a/app/src/app/actions/sign-out.test.ts
+++ b/app/src/app/actions/sign-out.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", async () => {
+  const { nextNavigationFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextNavigationFactory();
+});
+vi.mock("next/cache", async () => {
+  const { nextCacheFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextCacheFactory();
+});
+vi.mock("next/headers", async () => {
+  const { nextHeadersFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextHeadersFactory();
+});
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { getNextMockState, resetNextMocks } from "../../../test/helpers/next-mocks";
+import { makeSupabaseClient } from "../../../test/helpers/supabase-mock";
+import { createClient } from "@/utils/supabase/server";
+import { signOut } from "./sign-out";
+
+const mockedCreateClient = createClient as unknown as ReturnType<typeof vi.fn>;
+
+describe("signOut", () => {
+  beforeEach(() => {
+    resetNextMocks();
+    mockedCreateClient.mockReset();
+  });
+
+  it("calls supabase.auth.signOut exactly once", async () => {
+    const client = makeSupabaseClient({
+      auth: { signOut: { data: null, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signOut()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(client.auth.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates '/' with the 'layout' option so nested layouts refresh", async () => {
+    const client = makeSupabaseClient({
+      auth: { signOut: { data: null, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signOut()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { revalidatePath } = getNextMockState();
+    expect(revalidatePath).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  it("redirects the user back to '/' after signing out", async () => {
+    const client = makeSupabaseClient({
+      auth: { signOut: { data: null, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signOut()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalledWith("/");
+  });
+});

--- a/app/src/app/auth/callback/route.test.ts
+++ b/app/src/app/auth/callback/route.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { makeSupabaseClient } from "../../../../test/helpers/supabase-mock";
+import { createClient } from "@/utils/supabase/server";
+import { GET } from "./route";
+
+const mockedCreateClient = createClient as unknown as ReturnType<typeof vi.fn>;
+
+describe("GET /auth/callback", () => {
+  beforeEach(() => {
+    mockedCreateClient.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("redirects to /login?error=oauth_failed when the code query param is missing", async () => {
+    const req = new NextRequest("http://localhost:3000/auth/callback");
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/login?error=oauth_failed"
+    );
+    // No supabase client should be constructed when there is no code.
+    expect(mockedCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("redirects to `origin + next` in development regardless of x-forwarded-host", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const client = makeSupabaseClient({
+      auth: { exchangeCodeForSession: { data: { session: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/callback?code=abc&next=/dashboard",
+      { headers: { "x-forwarded-host": "nomadui.app" } }
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/dashboard"
+    );
+    expect(client.auth.exchangeCodeForSession).toHaveBeenCalledTimes(1);
+    expect(client.auth.exchangeCodeForSession).toHaveBeenCalledWith("abc");
+  });
+
+  it("redirects to `https://<forwarded-host><next>` in production when x-forwarded-host is present", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const client = makeSupabaseClient({
+      auth: { exchangeCodeForSession: { data: { session: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/callback?code=abc&next=/dashboard",
+      { headers: { "x-forwarded-host": "nomadui.app" } }
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "https://nomadui.app/dashboard"
+    );
+  });
+
+  it("redirects to `origin + next` in production when x-forwarded-host is absent", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const client = makeSupabaseClient({
+      auth: { exchangeCodeForSession: { data: { session: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "https://konomad.app/auth/callback?code=abc&next=/dashboard"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "https://konomad.app/dashboard"
+    );
+  });
+
+  it("redirects to /login?error=oauth_failed when exchangeCodeForSession returns an error", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const client = makeSupabaseClient({
+      auth: {
+        exchangeCodeForSession: {
+          data: null,
+          error: { message: "bad code" },
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/callback?code=bad&next=/dashboard"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/login?error=oauth_failed"
+    );
+    expect(client.auth.exchangeCodeForSession).toHaveBeenCalledWith("bad");
+  });
+
+  it("defaults `next` to '/' when the query param is omitted", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const client = makeSupabaseClient({
+      auth: { exchangeCodeForSession: { data: { session: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/callback?code=abc"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost:3000/");
+  });
+});

--- a/app/src/app/auth/confirm/route.test.ts
+++ b/app/src/app/auth/confirm/route.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { makeSupabaseClient } from "../../../../test/helpers/supabase-mock";
+import { createClient } from "@/utils/supabase/server";
+import { GET } from "./route";
+
+const mockedCreateClient = createClient as unknown as ReturnType<typeof vi.fn>;
+
+describe("GET /auth/confirm", () => {
+  beforeEach(() => {
+    mockedCreateClient.mockReset();
+  });
+
+  it("redirects to /auth/auth-code-error when token_hash and type are missing", async () => {
+    const req = new NextRequest("http://localhost:3000/auth/confirm");
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/auth/auth-code-error"
+    );
+    // verifyOtp should never run without token_hash/type.
+    expect(mockedCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("redirects to '/' when verifyOtp succeeds and `next` is not provided", async () => {
+    const client = makeSupabaseClient({
+      auth: { verifyOtp: { data: { user: { id: "u1" } }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/confirm?token_hash=abc&type=signup"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    // Route swaps the pathname on a cloned nextUrl, so query params from the
+    // incoming request are preserved on the redirect target. Assert on
+    // origin+pathname only.
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin).toBe("http://localhost:3000");
+    expect(location.pathname).toBe("/");
+    expect(client.auth.verifyOtp).toHaveBeenCalledTimes(1);
+    expect(client.auth.verifyOtp).toHaveBeenCalledWith({
+      type: "signup",
+      token_hash: "abc",
+    });
+  });
+
+  it("redirects to the supplied `next` path when verifyOtp succeeds", async () => {
+    const client = makeSupabaseClient({
+      auth: { verifyOtp: { data: { user: { id: "u1" } }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/confirm?token_hash=abc&type=magiclink&next=/profile"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin).toBe("http://localhost:3000");
+    expect(location.pathname).toBe("/profile");
+    expect(client.auth.verifyOtp).toHaveBeenCalledWith({
+      type: "magiclink",
+      token_hash: "abc",
+    });
+  });
+
+  it("redirects to /auth/auth-code-error when verifyOtp returns an error", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        verifyOtp: { data: null, error: { message: "invalid token" } },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const req = new NextRequest(
+      "http://localhost:3000/auth/confirm?token_hash=bad&type=signup&next=/profile"
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin).toBe("http://localhost:3000");
+    expect(location.pathname).toBe("/auth/auth-code-error");
+    expect(client.auth.verifyOtp).toHaveBeenCalledWith({
+      type: "signup",
+      token_hash: "bad",
+    });
+  });
+});

--- a/app/src/app/login/actions.test.ts
+++ b/app/src/app/login/actions.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", async () => {
+  const { nextNavigationFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextNavigationFactory();
+});
+vi.mock("next/cache", async () => {
+  const { nextCacheFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextCacheFactory();
+});
+vi.mock("next/headers", async () => {
+  const { nextHeadersFactory } = await import(
+    "../../../test/helpers/next-mocks"
+  );
+  return nextHeadersFactory();
+});
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { getNextMockState, resetNextMocks } from "../../../test/helpers/next-mocks";
+import { makeSupabaseClient } from "../../../test/helpers/supabase-mock";
+import { createClient } from "@/utils/supabase/server";
+import { signInWithGoogle, login, signup } from "./actions";
+
+const mockedCreateClient = createClient as unknown as ReturnType<typeof vi.fn>;
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  return fd;
+}
+
+describe("signInWithGoogle", () => {
+  beforeEach(() => {
+    resetNextMocks();
+    mockedCreateClient.mockReset();
+  });
+
+  it("passes the 'origin' header through untouched when it already begins with http", async () => {
+    const { headersMap } = getNextMockState();
+    headersMap.set("origin", "http://localhost:3000");
+
+    const client = makeSupabaseClient({
+      auth: {
+        signInWithOAuth: {
+          data: { url: "https://accounts.google.com/oauth", provider: "google" },
+          error: null,
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signInWithGoogle()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(client.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: {
+        redirectTo: "http://localhost:3000/auth/callback",
+      },
+    });
+  });
+
+  it("falls back to x-forwarded-host and prefixes https:// when the value lacks a scheme", async () => {
+    const { headersMap } = getNextMockState();
+    // No "origin" header set; only x-forwarded-host, and it starts without http.
+    headersMap.set("x-forwarded-host", "nomadui.vercel.app");
+
+    const client = makeSupabaseClient({
+      auth: {
+        signInWithOAuth: {
+          data: { url: "https://accounts.google.com/oauth", provider: "google" },
+          error: null,
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signInWithGoogle()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(client.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: {
+        redirectTo: "https://nomadui.vercel.app/auth/callback",
+      },
+    });
+  });
+
+  it("redirects to /login?error=... when signInWithOAuth returns an error", async () => {
+    const { headersMap } = getNextMockState();
+    headersMap.set("origin", "https://nomadui.vercel.app");
+
+    const client = makeSupabaseClient({
+      auth: {
+        signInWithOAuth: {
+          data: null,
+          error: { message: "OAuth provider unavailable" },
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signInWithGoogle()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    const target = redirect.mock.calls[0][0] as string;
+    expect(target.startsWith("/login?error=")).toBe(true);
+    expect(decodeURIComponent(target.split("error=")[1])).toBe(
+      "OAuth provider unavailable"
+    );
+  });
+
+  it("redirects to data.url when signInWithOAuth succeeds", async () => {
+    const { headersMap } = getNextMockState();
+    headersMap.set("origin", "https://nomadui.vercel.app");
+
+    const oauthUrl =
+      "https://accounts.google.com/o/oauth2/auth?client_id=xyz";
+    const client = makeSupabaseClient({
+      auth: {
+        signInWithOAuth: {
+          data: { url: oauthUrl, provider: "google" },
+          error: null,
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    await expect(signInWithGoogle()).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalledWith(oauthUrl);
+  });
+});
+
+describe("login", () => {
+  beforeEach(() => {
+    resetNextMocks();
+    mockedCreateClient.mockReset();
+  });
+
+  it("revalidates the layout and redirects to '/' on success", async () => {
+    const client = makeSupabaseClient({
+      auth: { signInWithPassword: { data: { user: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const fd = makeFormData({
+      email: "user@example.com",
+      password: "hunter2",
+    });
+
+    await expect(login(fd)).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(client.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: "user@example.com",
+      password: "hunter2",
+    });
+
+    const { redirect, revalidatePath } = getNextMockState();
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+    expect(redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects to /login?error=... when credentials are invalid and skips revalidate", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        signInWithPassword: {
+          data: null,
+          error: { message: "Invalid login credentials" },
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const fd = makeFormData({
+      email: "user@example.com",
+      password: "wrong",
+    });
+
+    await expect(login(fd)).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect, revalidatePath } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    const target = redirect.mock.calls[0][0] as string;
+    expect(target.startsWith("/login?error=")).toBe(true);
+    expect(decodeURIComponent(target.split("error=")[1])).toBe(
+      "Invalid login credentials"
+    );
+    // On the error branch we never reach revalidate/redirect("/").
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("signup", () => {
+  beforeEach(() => {
+    resetNextMocks();
+    mockedCreateClient.mockReset();
+  });
+
+  it("redirects to /register?message=... with the verification hint on success", async () => {
+    const client = makeSupabaseClient({
+      auth: { signUp: { data: { user: {} }, error: null } },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const fd = makeFormData({
+      email: "new@example.com",
+      password: "hunter2",
+    });
+
+    await expect(signup(fd)).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(client.auth.signUp).toHaveBeenCalledWith({
+      email: "new@example.com",
+      password: "hunter2",
+    });
+
+    const { redirect, revalidatePath } = getNextMockState();
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+    expect(redirect).toHaveBeenCalledTimes(1);
+    const target = redirect.mock.calls[0][0] as string;
+    expect(target.startsWith("/register?message=")).toBe(true);
+    expect(decodeURIComponent(target.split("message=")[1])).toBe(
+      "이메일을 확인해주세요."
+    );
+  });
+
+  it("redirects to /register?error=... when signUp fails", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        signUp: {
+          data: null,
+          error: { message: "User already registered" },
+        },
+      },
+    });
+    mockedCreateClient.mockResolvedValue(client);
+
+    const fd = makeFormData({
+      email: "dup@example.com",
+      password: "hunter2",
+    });
+
+    await expect(signup(fd)).rejects.toThrow(/NEXT_REDIRECT/);
+
+    const { redirect, revalidatePath } = getNextMockState();
+    expect(redirect).toHaveBeenCalledTimes(1);
+    const target = redirect.mock.calls[0][0] as string;
+    expect(target.startsWith("/register?error=")).toBe(true);
+    expect(decodeURIComponent(target.split("error=")[1])).toBe(
+      "User already registered"
+    );
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/sections/city-card.test.tsx
+++ b/app/src/components/sections/city-card.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const voteCityMock = vi.fn();
+vi.mock("@/app/actions/city-vote", () => ({
+  voteCity: (...args: unknown[]) => voteCityMock(...args),
+}));
+
+import { render, screen, waitFor } from "../../../test/helpers/render";
+import {
+  seoulWithWeather,
+  busanWithWeather,
+} from "../../../test/fixtures/cities";
+import type { CityWithWeather } from "@/lib/database.types";
+import { CityCard } from "./city-card";
+
+// TODO(city-card-optimistic): `useOptimistic` only persists its optimistic
+// value while the enclosing action is in-flight. The current source wraps
+// `mutate(...)` + `voteCity(...)` in a *synchronous* `startTransition(() =>
+// {...})` callback that does NOT `return`/`await` the `voteCity(...)`
+// promise, so React treats the action as "complete" in the same tick and
+// reverts the optimistic state before any render commits with the new
+// counts. That means we cannot observe `likeCount + 1` / `dislikeCount - 1`
+// from the DOM in this test environment. When the source is updated to
+// return or await the server-action promise from inside `startTransition`
+// (or is refactored to `useActionState`), these tests should be expanded to
+// also assert the optimistic count / active-vote styling after the click.
+// For now we assert the dispatched `voteCity(...)` call — which is the
+// behavior we can verify without touching the source.
+
+describe("<CityCard />", () => {
+  beforeEach(() => {
+    voteCityMock.mockReset();
+    voteCityMock.mockResolvedValue(undefined);
+  });
+
+  it("renders the basic city info: name, english name, region, formatted cost, and rank", () => {
+    render(<CityCard city={seoulWithWeather} />);
+
+    expect(screen.getByText("서울")).toBeInTheDocument();
+    expect(screen.getByText("(Seoul)")).toBeInTheDocument();
+    expect(
+      screen.getByText(`대한민국 · ${seoulWithWeather.region}`)
+    ).toBeInTheDocument();
+    // ₩ formatted using toLocaleString
+    expect(screen.getByText("₩1,850,000/월")).toBeInTheDocument();
+    // Rank badge
+    expect(screen.getByText("#1")).toBeInTheDocument();
+    // Internet speed
+    expect(
+      screen.getByText(`📶 ${seoulWithWeather.internet_speed}Mbps`)
+    ).toBeInTheDocument();
+  });
+
+  it("renders weather temperature and AQI when city_weather is present", () => {
+    render(<CityCard city={seoulWithWeather} />);
+
+    // Seoul fixture: temp=9, emoji=☀️, aqi=72 (>50 => 😷)
+    expect(screen.getByText(/☀️\s*9°C/)).toBeInTheDocument();
+    expect(screen.getByText(/😷\s*AQI 72/)).toBeInTheDocument();
+  });
+
+  it("uses the 😊 face for AQI <= 50", () => {
+    render(<CityCard city={busanWithWeather} />);
+    // Busan fixture: aqi=45 -> 😊
+    expect(screen.getByText(/😊\s*AQI 45/)).toBeInTheDocument();
+  });
+
+  it("hides weather info when city_weather is null", () => {
+    const cityNoWeather: CityWithWeather = {
+      ...seoulWithWeather,
+      city_weather: null,
+    };
+    render(<CityCard city={cityNoWeather} />);
+
+    expect(screen.queryByText(/°C/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/AQI/)).not.toBeInTheDocument();
+  });
+
+  it("hides the rank badge when rank is null", () => {
+    const cityNoRank: CityWithWeather = {
+      ...seoulWithWeather,
+      rank: null,
+    };
+    render(<CityCard city={cityNoRank} />);
+
+    // No #1, #2, etc. for rank badge
+    expect(screen.queryByText(/^#\d+$/)).not.toBeInTheDocument();
+    // Name should still render
+    expect(screen.getByText("서울")).toBeInTheDocument();
+  });
+
+  it("applies active like styles to the 👍 button when initialVote='like'", () => {
+    render(<CityCard city={seoulWithWeather} initialVote="like" />);
+
+    const likeBtn = screen.getByRole("button", { name: "👍" });
+    expect(likeBtn.className).toMatch(/text-blue-600/);
+    expect(likeBtn.className).toMatch(/bg-blue-100/);
+
+    // And the like count text uses the active color
+    const likeCount = screen.getByText(String(seoulWithWeather.like_count));
+    expect(likeCount.className).toMatch(/text-blue-600/);
+  });
+
+  it("applies active dislike styles to the 👎 button when initialVote='dislike'", () => {
+    render(<CityCard city={seoulWithWeather} initialVote="dislike" />);
+
+    const dislikeBtn = screen.getByRole("button", { name: "👎" });
+    expect(dislikeBtn.className).toMatch(/text-red-600/);
+    expect(dislikeBtn.className).toMatch(/bg-red-100/);
+
+    const dislikeCount = screen.getByText(
+      String(seoulWithWeather.dislike_count)
+    );
+    expect(dislikeCount.className).toMatch(/text-red-600/);
+  });
+
+  it("calls voteCity(cityId, 'like') when clicking 👍 with no prior vote", async () => {
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="none" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(voteCityMock).toHaveBeenCalledWith(seoulWithWeather.id, "like");
+  });
+
+  it("calls voteCity(cityId, 'clear') when clicking 👍 while already liked", async () => {
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="like" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(voteCityMock).toHaveBeenCalledWith(seoulWithWeather.id, "clear");
+  });
+
+  it("calls voteCity(cityId, 'like') when switching from dislike to like", async () => {
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="dislike" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(voteCityMock).toHaveBeenCalledWith(seoulWithWeather.id, "like");
+  });
+
+  it("calls voteCity(cityId, 'dislike') when clicking 👎 with no prior vote", async () => {
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="none" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👎" }));
+
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(voteCityMock).toHaveBeenCalledWith(seoulWithWeather.id, "dislike");
+  });
+
+  it("calls voteCity(cityId, 'clear') when clicking 👎 while already disliked", async () => {
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="dislike" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👎" }));
+
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalledTimes(1);
+    });
+    expect(voteCityMock).toHaveBeenCalledWith(seoulWithWeather.id, "clear");
+  });
+
+  it("wraps the card in a <Link> to /city/[id] and preserves that href after vote interactions", async () => {
+    const { user, container } = render(
+      <CityCard city={seoulWithWeather} initialVote="none" />
+    );
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe(`/city/${seoulWithWeather.id}`);
+
+    // The button handlers call e.preventDefault() + e.stopPropagation() so
+    // the Link's navigation should not be triggered. We can observe this
+    // indirectly by confirming the anchor's href is still in place and the
+    // element is still connected after a click.
+    await user.click(screen.getByRole("button", { name: "👍" }));
+    await waitFor(() => {
+      expect(voteCityMock).toHaveBeenCalled();
+    });
+    expect(link?.getAttribute("href")).toBe(`/city/${seoulWithWeather.id}`);
+    expect(link?.isConnected).toBe(true);
+  });
+
+  it("renders the tag-like metadata: budget, area, environment (joined), and best_season (joined)", () => {
+    render(<CityCard city={seoulWithWeather} />);
+
+    expect(screen.getByText(seoulWithWeather.budget)).toBeInTheDocument();
+    expect(screen.getByText(seoulWithWeather.area)).toBeInTheDocument();
+    expect(
+      screen.getByText(seoulWithWeather.environment.join(", "))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(seoulWithWeather.best_season.join(", "))
+    ).toBeInTheDocument();
+  });
+});

--- a/app/src/components/sections/city-grid.test.tsx
+++ b/app/src/components/sections/city-grid.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const voteCityMock = vi.fn();
+vi.mock("@/app/actions/city-vote", () => ({
+  voteCity: (...args: unknown[]) => voteCityMock(...args),
+}));
+
+import { render, screen, within } from "../../../test/helpers/render";
+import {
+  seoulWithWeather,
+  busanWithWeather,
+  gangneungWithWeather,
+  citiesWithWeather,
+} from "../../../test/fixtures/cities";
+import { CityGrid } from "./city-grid";
+
+describe("<CityGrid />", () => {
+  beforeEach(() => {
+    voteCityMock.mockReset();
+    voteCityMock.mockResolvedValue(undefined);
+  });
+
+  it("always renders the '도시 리스트' heading", () => {
+    render(<CityGrid cities={[]} />);
+    expect(
+      screen.getByRole("heading", { name: "도시 리스트" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty-state message when cities is an empty array", () => {
+    render(<CityGrid cities={[]} />);
+
+    expect(
+      screen.getByText(/조건에 맞는 도시가 없어요/)
+    ).toBeInTheDocument();
+    // "더 많은 도시 보기" should NOT be rendered in empty state
+    expect(
+      screen.queryByRole("button", { name: /더 많은 도시 보기/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders one CityCard per city (identified by its Link href)", () => {
+    const { container } = render(<CityGrid cities={citiesWithWeather} />);
+
+    // Each card is wrapped in an <a href="/city/{id}">.
+    const cityLinks = container.querySelectorAll('a[href^="/city/"]');
+    expect(cityLinks).toHaveLength(citiesWithWeather.length);
+
+    // Sanity: the rendered names appear
+    expect(screen.getByText("서울")).toBeInTheDocument();
+    expect(screen.getByText("부산")).toBeInTheDocument();
+    expect(screen.getByText("강릉")).toBeInTheDocument();
+  });
+
+  it("renders the '더 많은 도시 보기' load-more button when there are cities", () => {
+    render(<CityGrid cities={citiesWithWeather} />);
+
+    expect(
+      screen.getByRole("button", { name: /더 많은 도시 보기/ })
+    ).toBeInTheDocument();
+  });
+
+  it("passes userVotes through to each CityCard so the initial vote state is reflected", () => {
+    const userVotes: Record<string, "like" | "dislike"> = {
+      [seoulWithWeather.id]: "like",
+      [busanWithWeather.id]: "dislike",
+      // gangneung left out -> defaults to "none"
+    };
+
+    const { container } = render(
+      <CityGrid cities={citiesWithWeather} userVotes={userVotes} />
+    );
+
+    const seoulLink = container.querySelector(
+      `a[href="/city/${seoulWithWeather.id}"]`
+    ) as HTMLElement | null;
+    const busanLink = container.querySelector(
+      `a[href="/city/${busanWithWeather.id}"]`
+    ) as HTMLElement | null;
+    const gangneungLink = container.querySelector(
+      `a[href="/city/${gangneungWithWeather.id}"]`
+    ) as HTMLElement | null;
+
+    expect(seoulLink).not.toBeNull();
+    expect(busanLink).not.toBeNull();
+    expect(gangneungLink).not.toBeNull();
+
+    // Seoul card -> like active styling on 👍
+    const seoulLike = within(seoulLink!).getByRole("button", { name: "👍" });
+    expect(seoulLike.className).toMatch(/text-blue-600/);
+    expect(seoulLike.className).toMatch(/bg-blue-100/);
+
+    // Busan card -> dislike active styling on 👎
+    const busanDislike = within(busanLink!).getByRole("button", {
+      name: "👎",
+    });
+    expect(busanDislike.className).toMatch(/text-red-600/);
+    expect(busanDislike.className).toMatch(/bg-red-100/);
+
+    // Gangneung card -> neither button should be in active color
+    const gangneungLike = within(gangneungLink!).getByRole("button", {
+      name: "👍",
+    });
+    const gangneungDislike = within(gangneungLink!).getByRole("button", {
+      name: "👎",
+    });
+    expect(gangneungLike.className).not.toMatch(/bg-blue-100/);
+    expect(gangneungDislike.className).not.toMatch(/bg-red-100/);
+  });
+});

--- a/app/src/components/sections/filter-bar.test.tsx
+++ b/app/src/components/sections/filter-bar.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "../../../test/helpers/render";
+import { screen, fireEvent } from "@testing-library/react";
+
+/**
+ * The filter bar wires @base-ui/react's <Select> (Portal + Positioner) which is
+ * awkward to drive with userEvent under happy-dom. We stub `@/components/ui/select`
+ * with a native <select> shim that preserves the `onValueChange` contract, so the
+ * tests focus on the component's URL/router logic rather than base-ui DOM.
+ */
+vi.mock("@/components/ui/select", async () => {
+  const React = await import("react");
+  type SelectProps = {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children?: React.ReactNode;
+  };
+  const Select = ({ value, onValueChange, children }: SelectProps) => {
+    // Flatten any SelectContent/SelectItem children into <option>s.
+    const options: React.ReactNode[] = [];
+    const visit = (node: React.ReactNode) => {
+      React.Children.forEach(node, (child: React.ReactNode) => {
+        if (!React.isValidElement(child)) return;
+        const el = child as React.ReactElement<Record<string, unknown>>;
+        const props = el.props as Record<string, unknown>;
+        if ("value" in props && typeof props.value === "string") {
+          options.push(
+            React.createElement(
+              "option",
+              { key: props.value as string, value: props.value as string },
+              props.children as React.ReactNode,
+            ),
+          );
+        } else if (props && props.children) {
+          visit(props.children as React.ReactNode);
+        }
+      });
+    };
+    visit(children);
+    return React.createElement(
+      "select",
+      {
+        "data-testid": "filter-select",
+        value: value ?? "",
+        onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
+          onValueChange?.(e.target.value),
+      },
+      options,
+    );
+  };
+
+  const passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+
+  return {
+    Select,
+    SelectTrigger: passthrough,
+    SelectValue: passthrough,
+    SelectContent: passthrough,
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children?: React.ReactNode;
+    }) =>
+      React.createElement(
+        "span",
+        { "data-value": value, "data-slot": "select-item" },
+        children,
+      ),
+  };
+});
+
+// Mutable URLSearchParams state exposed to tests via `setInitialParams`.
+let currentParams = new URLSearchParams();
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace,
+    push: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: () => currentParams,
+}));
+
+import { FilterBar } from "./filter-bar";
+
+function setInitialParams(qs: string) {
+  currentParams = new URLSearchParams(qs);
+}
+
+describe("FilterBar", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    setInitialParams("");
+  });
+
+  it("renders the four filter labels: 예산 / 지역 / 환경 / 최고 계절", () => {
+    render(<FilterBar />);
+
+    expect(screen.getByText("예산")).toBeInTheDocument();
+    expect(screen.getByText("지역")).toBeInTheDocument();
+    expect(screen.getByText("환경")).toBeInTheDocument();
+    expect(screen.getByText("최고 계절")).toBeInTheDocument();
+  });
+
+  it("reflects the budget URL param as the budget select's initial value", () => {
+    setInitialParams("budget=100%EB%A7%8C%EC%9B%90%20%EC%9D%B4%ED%95%98");
+    render(<FilterBar />);
+
+    const selects = screen.getAllByTestId(
+      "filter-select",
+    ) as HTMLSelectElement[];
+
+    // Order: budget, region, environment, bestSeason (Object.keys order).
+    expect(selects[0].value).toBe("100만원 이하");
+    expect(selects[1].value).toBe("all");
+    expect(selects[2].value).toBe("all");
+    expect(selects[3].value).toBe("all");
+  });
+
+  it("calls router.replace with the new URL when a select value changes", () => {
+    render(<FilterBar />);
+
+    const selects = screen.getAllByTestId(
+      "filter-select",
+    ) as HTMLSelectElement[];
+
+    // Change the budget select (index 0) to "200만원 이상".
+    fireEvent.change(selects[0], { target: { value: "200만원 이상" } });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const [url] = replace.mock.calls[0];
+    expect(url).toMatch(/^\/\?/);
+    const qs = new URLSearchParams(url.slice(2));
+    expect(qs.get("budget")).toBe("200만원 이상");
+  });
+
+  it("removes the param from the URL when 'all' is selected", () => {
+    setInitialParams("budget=100%EB%A7%8C%EC%9B%90%20%EC%9D%B4%ED%95%98");
+    render(<FilterBar />);
+
+    const selects = screen.getAllByTestId(
+      "filter-select",
+    ) as HTMLSelectElement[];
+
+    // Budget select is currently "100만원 이하" — switching to "all" should
+    // drop the param, resulting in router.replace("/", { scroll: false }).
+    fireEvent.change(selects[0], { target: { value: "all" } });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const [url] = replace.mock.calls[0];
+    expect(url).toBe("/");
+  });
+
+  it("preserves other params when changing a single filter", () => {
+    setInitialParams("region=%EC%88%98%EB%8F%84%EA%B6%8C&budget=100%EB%A7%8C%EC%9B%90%20%EC%9D%B4%ED%95%98");
+    render(<FilterBar />);
+
+    const selects = screen.getAllByTestId(
+      "filter-select",
+    ) as HTMLSelectElement[];
+
+    // Change budget (index 0) to "200만원 이상"; region should be untouched.
+    fireEvent.change(selects[0], { target: { value: "200만원 이상" } });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const [url] = replace.mock.calls[0];
+    const qs = new URLSearchParams(url.slice(2));
+    expect(qs.get("budget")).toBe("200만원 이상");
+    expect(qs.get("region")).toBe("수도권");
+  });
+
+  it("passes { scroll: false } to router.replace so the page doesn't jump", () => {
+    render(<FilterBar />);
+
+    const selects = screen.getAllByTestId(
+      "filter-select",
+    ) as HTMLSelectElement[];
+
+    fireEvent.change(selects[1], { target: { value: "제주도" } });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const [, opts] = replace.mock.calls[0];
+    expect(opts).toEqual({ scroll: false });
+  });
+});

--- a/app/src/components/sections/hero.test.tsx
+++ b/app/src/components/sections/hero.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { render } from "../../../test/helpers/render";
+import { Hero } from "./hero";
+
+describe("Hero (non-authenticated / default)", () => {
+  it("renders the email input, 무료로 시작하기 CTA, and login hint", () => {
+    render(<Hero />);
+
+    // Email input with the expected placeholder.
+    const email = screen.getByPlaceholderText("이메일을 입력하세요...");
+    expect(email).toBeInTheDocument();
+    expect(email).toHaveAttribute("type", "email");
+
+    // CTA button.
+    expect(
+      screen.getByRole("button", { name: /무료로 시작하기/ }),
+    ).toBeInTheDocument();
+
+    // Hint copy shown only in the non-authenticated branch.
+    expect(
+      screen.getByText("이미 계정이 있으시면 로그인됩니다"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Hero (authenticated)", () => {
+  it("hides the email CTA block when isAuthenticated is true", () => {
+    render(<Hero isAuthenticated />);
+
+    expect(
+      screen.queryByPlaceholderText("이메일을 입력하세요..."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /무료로 시작하기/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("이미 계정이 있으시면 로그인됩니다"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Hero (shared chrome)", () => {
+  it("always renders the community badge (independent of auth state)", () => {
+    const { unmount } = render(<Hero />);
+    expect(
+      screen.getByText(/#1 한국 디지털 노마드 커뮤니티 Since 2026/),
+    ).toBeInTheDocument();
+    unmount();
+
+    render(<Hero isAuthenticated />);
+    expect(
+      screen.getByText(/#1 한국 디지털 노마드 커뮤니티 Since 2026/),
+    ).toBeInTheDocument();
+  });
+
+  it("always renders the member avatar strip with the +2k badge", () => {
+    const { unmount } = render(<Hero />);
+    expect(screen.getByText("+2k")).toBeInTheDocument();
+    unmount();
+
+    render(<Hero isAuthenticated />);
+    expect(screen.getByText("+2k")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/sections/navbar.test.tsx
+++ b/app/src/components/sections/navbar.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import { render } from "../../../test/helpers/render";
+import { Navbar, type NavbarUser } from "./navbar";
+import { signOut } from "@/app/actions/sign-out";
+
+vi.mock("@/app/actions/sign-out", () => ({
+  signOut: vi.fn(),
+}));
+
+describe("Navbar (logged-out, desktop)", () => {
+  it("renders 로그인 and 회원가입 links pointing to /login and /register", () => {
+    render(<Navbar user={null} />);
+
+    // Both desktop and mobile menus render the links when the menu is open,
+    // but by default only the desktop variant is in the DOM tree.
+    const loginLinks = screen.getAllByRole("link", { name: /^로그인$/ });
+    const registerLinks = screen.getAllByRole("link", { name: /회원가입/ });
+
+    expect(loginLinks.length).toBeGreaterThan(0);
+    expect(registerLinks.length).toBeGreaterThan(0);
+    expect(loginLinks[0]).toHaveAttribute("href", "/login");
+    expect(registerLinks[0]).toHaveAttribute("href", "/register");
+  });
+
+  it("does not render an avatar image or the logout form", () => {
+    const { container } = render(<Navbar user={null} />);
+
+    // No img (avatar_url) and no logout button.
+    expect(container.querySelector("img")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /로그아웃/ }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Navbar (logged-in, desktop)", () => {
+  it("renders the username from user.username", () => {
+    const user: NavbarUser = {
+      email: "nomad@example.com",
+      username: "해리노마드",
+      avatar_url: null,
+    };
+    render(<Navbar user={user} />);
+
+    expect(screen.getAllByText("해리노마드").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to the email prefix when username is null", () => {
+    const user: NavbarUser = {
+      email: "harry@example.com",
+      username: null,
+      avatar_url: null,
+    };
+    render(<Navbar user={user} />);
+
+    expect(screen.getAllByText("harry").length).toBeGreaterThan(0);
+  });
+
+  it("renders an <img> when avatar_url is present", () => {
+    const user: NavbarUser = {
+      email: "nomad@example.com",
+      username: "해리",
+      avatar_url: "https://cdn.example.com/avatar.png",
+    };
+    const { container } = render(<Navbar user={user} />);
+
+    const imgs = container.querySelectorAll("img");
+    expect(imgs.length).toBeGreaterThan(0);
+    expect(imgs[0]).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/avatar.png",
+    );
+    expect(imgs[0]).toHaveAttribute("alt", "해리");
+  });
+
+  it("renders the uppercase initial span when avatar_url is missing", () => {
+    const user: NavbarUser = {
+      email: "nomad@example.com",
+      username: "harry",
+      avatar_url: null,
+    };
+    const { container } = render(<Navbar user={user} />);
+
+    // No <img>, but an initial span should be present.
+    expect(container.querySelector("img")).toBeNull();
+    // The component uppercases the first character of displayName.
+    expect(screen.getAllByText("H").length).toBeGreaterThan(0);
+  });
+
+  it("wires the desktop logout form action to the imported signOut server action", () => {
+    const user: NavbarUser = {
+      email: "nomad@example.com",
+      username: "해리",
+      avatar_url: null,
+    };
+    const { container } = render(<Navbar user={user} />);
+
+    const forms = container.querySelectorAll("form");
+    expect(forms.length).toBeGreaterThan(0);
+    // React 19 passes the function through as the form action prop; when
+    // rendered the attribute is still present on the form element via the
+    // React runtime. We assert against the imported signOut symbol being the
+    // same mocked function we injected above.
+    expect(signOut).toBeDefined();
+    expect(vi.isMockFunction(signOut)).toBe(true);
+    // Each logout button lives inside a <form>; submitting it would invoke
+    // the action. We at least verify the form + button pair exists in the DOM.
+    const logoutButtons = screen.getAllByRole("button", { name: /로그아웃/ });
+    expect(logoutButtons.length).toBeGreaterThan(0);
+    expect(logoutButtons[0].closest("form")).not.toBeNull();
+  });
+});
+
+describe("Navbar mobile menu", () => {
+  it("toggles the mobile menu open/close when the hamburger button is clicked", async () => {
+    const { user, container } = render(<Navbar user={null} />);
+
+    const toggle = screen.getByRole("button", { name: "메뉴 열기" });
+
+    // Closed by default — only the desktop menu's login/register links exist.
+    // Desktop wrapper is hidden via `hidden lg:flex`, but RTL still sees its
+    // children, so we count link occurrences before and after toggle.
+    const initialLoginCount = screen.getAllByRole("link", {
+      name: /^로그인$/,
+    }).length;
+
+    await user.click(toggle);
+
+    // Mobile menu mounts its own link copy — count should grow.
+    const afterOpenCount = screen.getAllByRole("link", {
+      name: /^로그인$/,
+    }).length;
+    expect(afterOpenCount).toBeGreaterThan(initialLoginCount);
+
+    // Clicking again closes the menu — the mobile-only copy unmounts.
+    await user.click(toggle);
+    const afterCloseCount = screen.getAllByRole("link", {
+      name: /^로그인$/,
+    }).length;
+    expect(afterCloseCount).toBe(initialLoginCount);
+
+    // Sanity: container still contains the nav root.
+    expect(container.querySelector("nav")).not.toBeNull();
+  });
+});
+
+describe("Navbar mobile menu (logged-in)", () => {
+  it("renders displayName and a logout button inside the mobile menu when opened", async () => {
+    const user: NavbarUser = {
+      email: "nomad@example.com",
+      username: "해리",
+      avatar_url: null,
+    };
+    const { user: ue } = render(<Navbar user={user} />);
+
+    const toggle = screen.getByRole("button", { name: "메뉴 열기" });
+    await ue.click(toggle);
+
+    // With the mobile menu open, the username + logout button should appear
+    // at least twice (desktop copy + mobile copy).
+    expect(screen.getAllByText("해리").length).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getAllByRole("button", { name: /로그아웃/ }).length,
+    ).toBeGreaterThanOrEqual(2);
+
+    // The mobile menu copy lives under a lg:hidden container — verify at
+    // least one logout button is inside a <form>.
+    const logoutButtons = screen.getAllByRole("button", { name: /로그아웃/ });
+    const insideForm = logoutButtons.some(
+      (btn) => btn.closest("form") !== null,
+    );
+    expect(insideForm).toBe(true);
+
+    // Extra: within the nav, the mobile-menu container should exist after open.
+    const nav = screen.getByRole("navigation");
+    // The component marks the mobile container with border-t + lg:hidden —
+    // we verify an element with those classes exists below the top bar.
+    const mobileContainer = within(nav).getAllByText("해리")[1];
+    expect(mobileContainer).toBeInTheDocument();
+  });
+});

--- a/app/src/lib/current-user.test.ts
+++ b/app/src/lib/current-user.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import {
+  makeSupabaseClient,
+  type SupabaseClientMock,
+} from "../../test/helpers/supabase-mock";
+import { authUser, profileRow } from "../../test/fixtures/profiles";
+
+// `current-user.ts` imports `"server-only"`, which throws when imported
+// outside of a React server context. Stub it so the module is loadable
+// under Vitest.
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/utils/supabase/server";
+import { getNavbarUser } from "@/lib/current-user";
+
+const createClientMock = createClient as unknown as Mock;
+
+function setClient(client: SupabaseClientMock) {
+  createClientMock.mockResolvedValue(client);
+}
+
+beforeEach(() => {
+  createClientMock.mockReset();
+});
+
+describe("getNavbarUser", () => {
+  it("returns null when no auth user is signed in", async () => {
+    const client = makeSupabaseClient({ auth: { user: null } });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result).toBeNull();
+    expect(client.auth.getUser).toHaveBeenCalledTimes(1);
+    // Should short-circuit before touching the profiles table.
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("returns username and avatar_url from the profile row", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: authUser },
+      from: {
+        profiles: {
+          select: { data: [profileRow], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result).toEqual({
+      email: authUser.email,
+      username: profileRow.username,
+      avatar_url: profileRow.avatar_url,
+    });
+    expect(client.from).toHaveBeenCalledWith("profiles");
+    expect(client.calls.profiles.select[0][0]).toBe("username, avatar_url");
+    expect(client.calls.profiles.eq).toEqual([["id", authUser.id]]);
+    expect(client.calls.profiles.maybeSingle).toEqual([[]]);
+  });
+
+  it("falls back to user_metadata.avatar_url when the profile is missing", async () => {
+    const client = makeSupabaseClient({
+      auth: { user: authUser },
+      from: {
+        profiles: {
+          // maybeSingle will see an empty array and return { data: null }
+          select: { data: [], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result).toEqual({
+      email: authUser.email,
+      username: null,
+      avatar_url: authUser.user_metadata?.avatar_url,
+    });
+  });
+
+  it("returns avatar_url = null when neither the profile nor user_metadata has one", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        user: { id: "user-2", email: "no-avatar@example.com" },
+      },
+      from: {
+        profiles: {
+          select: { data: [], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result).toEqual({
+      email: "no-avatar@example.com",
+      username: null,
+      avatar_url: null,
+    });
+  });
+
+  it("preserves the user's email on the returned NavbarUser", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        user: {
+          id: "user-3",
+          email: "email-preserved@example.com",
+          user_metadata: {},
+        },
+      },
+      from: {
+        profiles: {
+          select: {
+            data: [
+              {
+                ...profileRow,
+                id: "user-3",
+                username: "preserved",
+                avatar_url: "https://example.com/preserved.png",
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result?.email).toBe("email-preserved@example.com");
+    expect(result?.username).toBe("preserved");
+    expect(result?.avatar_url).toBe("https://example.com/preserved.png");
+  });
+
+  it("prefers the profile avatar_url over user_metadata.avatar_url", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        user: {
+          id: authUser.id,
+          email: authUser.email,
+          user_metadata: { avatar_url: "https://example.com/from-oauth.png" },
+        },
+      },
+      from: {
+        profiles: {
+          select: {
+            data: [
+              {
+                ...profileRow,
+                avatar_url: "https://example.com/from-profile.png",
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result?.avatar_url).toBe("https://example.com/from-profile.png");
+  });
+
+  it("returns null email when the auth user's email is missing", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        user: { id: "user-4", email: null, user_metadata: {} },
+      },
+      from: {
+        profiles: {
+          select: { data: [], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getNavbarUser();
+
+    expect(result).toEqual({
+      email: null,
+      username: null,
+      avatar_url: null,
+    });
+  });
+});

--- a/app/src/lib/filters.test.ts
+++ b/app/src/lib/filters.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { AREAS, BUDGETS, parseFilters } from "./filters";
+
+describe("filters constants", () => {
+  it("BUDGETS 에 세 개의 예산 밴드가 정의되어 있다", () => {
+    expect(BUDGETS).toEqual([
+      "100만원 이하",
+      "100~200만원",
+      "200만원 이상",
+    ]);
+  });
+
+  it("AREAS 에 여섯 개의 지역이 정의되어 있다", () => {
+    expect(AREAS).toEqual([
+      "수도권",
+      "경상도",
+      "전라도",
+      "강원도",
+      "제주도",
+      "충청도",
+    ]);
+  });
+});
+
+describe("parseFilters", () => {
+  it("빈 객체를 받으면 빈 객체를 반환한다", () => {
+    expect(parseFilters({})).toEqual({});
+  });
+
+  it("undefined 만 포함된 객체를 받아도 빈 객체를 반환한다", () => {
+    expect(
+      parseFilters({
+        budget: undefined,
+        region: undefined,
+        environment: undefined,
+        bestSeason: undefined,
+      })
+    ).toEqual({});
+  });
+
+  it("BUDGETS 에 포함된 budget 값은 그대로 통과시킨다", () => {
+    expect(parseFilters({ budget: "100만원 이하" })).toEqual({
+      budget: "100만원 이하",
+    });
+    expect(parseFilters({ budget: "100~200만원" })).toEqual({
+      budget: "100~200만원",
+    });
+    expect(parseFilters({ budget: "200만원 이상" })).toEqual({
+      budget: "200만원 이상",
+    });
+  });
+
+  it("BUDGETS 에 없는 budget 값은 무시된다", () => {
+    expect(parseFilters({ budget: "50만원" })).toEqual({});
+    expect(parseFilters({ budget: "all" })).toEqual({});
+    expect(parseFilters({ budget: "" })).toEqual({});
+  });
+
+  it("AREAS 에 포함된 region 값은 area 키로 매핑된다", () => {
+    expect(parseFilters({ region: "수도권" })).toEqual({ area: "수도권" });
+    expect(parseFilters({ region: "제주도" })).toEqual({ area: "제주도" });
+    expect(parseFilters({ region: "충청도" })).toEqual({ area: "충청도" });
+  });
+
+  it("AREAS 에 없는 region 값은 무시된다", () => {
+    expect(parseFilters({ region: "서울" })).toEqual({});
+    expect(parseFilters({ region: "all" })).toEqual({});
+    expect(parseFilters({ region: "" })).toEqual({});
+  });
+
+  it("environment 는 'all' 과 빈 문자열을 제외하고 통과시킨다", () => {
+    expect(parseFilters({ environment: "도시" })).toEqual({
+      environment: "도시",
+    });
+    expect(parseFilters({ environment: "자연" })).toEqual({
+      environment: "자연",
+    });
+    expect(parseFilters({ environment: "all" })).toEqual({});
+    expect(parseFilters({ environment: "" })).toEqual({});
+  });
+
+  it("bestSeason 은 'all' 과 빈 문자열을 제외하고 통과시킨다", () => {
+    expect(parseFilters({ bestSeason: "봄" })).toEqual({
+      bestSeason: "봄",
+    });
+    expect(parseFilters({ bestSeason: "여름" })).toEqual({
+      bestSeason: "여름",
+    });
+    expect(parseFilters({ bestSeason: "all" })).toEqual({});
+    expect(parseFilters({ bestSeason: "" })).toEqual({});
+  });
+
+  it("여러 필터를 동시에 전달하면 유효한 것만 모아서 반환한다", () => {
+    expect(
+      parseFilters({
+        budget: "100~200만원",
+        region: "강원도",
+        environment: "자연",
+        bestSeason: "가을",
+      })
+    ).toEqual({
+      budget: "100~200만원",
+      area: "강원도",
+      environment: "자연",
+      bestSeason: "가을",
+    });
+  });
+
+  it("일부는 유효, 일부는 무효인 경우 유효한 것만 포함한다", () => {
+    expect(
+      parseFilters({
+        budget: "100만원 이하",
+        region: "서울",
+        environment: "all",
+        bestSeason: "겨울",
+      })
+    ).toEqual({
+      budget: "100만원 이하",
+      bestSeason: "겨울",
+    });
+  });
+
+  it("region 키는 입력이지만 출력 키는 area 로 정규화된다", () => {
+    const out = parseFilters({ region: "전라도" });
+    expect(out).toHaveProperty("area", "전라도");
+    expect(out).not.toHaveProperty("region");
+  });
+});

--- a/app/src/lib/format.test.ts
+++ b/app/src/lib/format.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { formatRelative } from "./format";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-04-22T12:00:00.000Z").getTime();
+
+function isoAgo(ms: number): string {
+  return new Date(NOW - ms).toISOString();
+}
+
+describe("formatRelative", () => {
+  it("1일 미만(23시간 59분 전)이면 '오늘' 을 반환한다", () => {
+    expect(formatRelative(isoAgo(DAY_MS - 60 * 1000), NOW)).toBe("오늘");
+  });
+
+  it("정확히 같은 시각이면 '오늘' 을 반환한다", () => {
+    expect(formatRelative(isoAgo(0), NOW)).toBe("오늘");
+  });
+
+  it("미래 시각(음수 diff)도 '오늘' 로 취급한다", () => {
+    expect(formatRelative(isoAgo(-60 * 1000), NOW)).toBe("오늘");
+  });
+
+  it("정확히 24시간 전이면 '1일 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS), NOW)).toBe("1일 전");
+  });
+
+  it("2~6일 범위는 '${days}일 전' 형식이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 2), NOW)).toBe("2일 전");
+    expect(formatRelative(isoAgo(DAY_MS * 3), NOW)).toBe("3일 전");
+    expect(formatRelative(isoAgo(DAY_MS * 6), NOW)).toBe("6일 전");
+  });
+
+  it("정확히 7일 전이면 '1주 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 7), NOW)).toBe("1주 전");
+  });
+
+  it("13일(1주차 후반)은 '1주 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 13), NOW)).toBe("1주 전");
+  });
+
+  it("14일은 '2주 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 14), NOW)).toBe("2주 전");
+  });
+
+  it("34일(5주 미만 경계)은 '4주 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 34), NOW)).toBe("4주 전");
+  });
+
+  it("35일(5주 진입)은 months 단위로 바뀌어 '1개월 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 35), NOW)).toBe("1개월 전");
+  });
+
+  it("60일은 '2개월 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 60), NOW)).toBe("2개월 전");
+  });
+
+  it("359일(12개월 미만)은 '11개월 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 359), NOW)).toBe("11개월 전");
+  });
+
+  it("365일(12개월 경계)은 '1년 전' 이다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 365), NOW)).toBe("1년 전");
+  });
+
+  it("2년 이상은 floor(days/365) 로 계산한다", () => {
+    expect(formatRelative(isoAgo(DAY_MS * 730), NOW)).toBe("2년 전");
+    expect(formatRelative(isoAgo(DAY_MS * 365 * 3), NOW)).toBe("3년 전");
+  });
+
+  it("now 파라미터를 명시하지 않으면 Date.now() 기준으로 동작한다", () => {
+    const iso = new Date(Date.now() - 60 * 1000).toISOString();
+    expect(formatRelative(iso)).toBe("오늘");
+  });
+});

--- a/app/src/lib/queries.test.ts
+++ b/app/src/lib/queries.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import {
+  makeSupabaseClient,
+  type SupabaseClientMock,
+} from "../../test/helpers/supabase-mock";
+import {
+  citiesWithWeather,
+  seoulWithWeather,
+} from "../../test/fixtures/cities";
+import { reviews } from "../../test/fixtures/reviews";
+
+// `queries.ts` has `import "server-only"` at the top, which throws when
+// imported outside of a React server context. Stub it out so the module is
+// loadable under Vitest.
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/utils/supabase/server";
+import {
+  getCities,
+  getCityById,
+  getReviewsByCity,
+  getRecentReviews,
+  getPressQuotes,
+  getCurrentUser,
+} from "@/lib/queries";
+
+const createClientMock = createClient as unknown as Mock;
+
+function setClient(client: SupabaseClientMock) {
+  createClientMock.mockResolvedValue(client);
+}
+
+beforeEach(() => {
+  createClientMock.mockReset();
+});
+
+describe("getCities", () => {
+  it("queries cities with weather, orders by rank, and uses default limit", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: {
+          select: { data: citiesWithWeather, error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getCities();
+
+    expect(result).toEqual(citiesWithWeather);
+    expect(client.from).toHaveBeenCalledWith("cities");
+    expect(client.calls.cities.select[0][0]).toBe("*, city_weather(*)");
+    expect(client.calls.cities.order[0]).toEqual([
+      "rank",
+      { ascending: true, nullsFirst: false },
+    ]);
+    expect(client.calls.cities.limit[0]).toEqual([48]);
+    expect(client.calls.cities.eq).toBeUndefined();
+    expect(client.calls.cities.contains).toBeUndefined();
+  });
+
+  it("applies budget filter via .eq(budget, …)", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: [seoulWithWeather], error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({ budget: "200만원 이상" });
+
+    expect(client.calls.cities.eq).toEqual([["budget", "200만원 이상"]]);
+  });
+
+  it("applies area filter via .eq(area, …)", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: citiesWithWeather, error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({ area: "수도권" });
+
+    expect(client.calls.cities.eq).toEqual([["area", "수도권"]]);
+  });
+
+  it("applies environment filter via .contains(environment, [value])", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: citiesWithWeather, error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({ environment: "카페작업" });
+
+    expect(client.calls.cities.contains).toEqual([
+      ["environment", ["카페작업"]],
+    ]);
+  });
+
+  it("applies bestSeason filter via .contains(best_season, [value])", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: citiesWithWeather, error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({ bestSeason: "가을" });
+
+    expect(client.calls.cities.contains).toEqual([["best_season", ["가을"]]]);
+  });
+
+  it("composes every filter in order (budget, area, environment, bestSeason)", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: [seoulWithWeather], error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({
+      budget: "200만원 이상",
+      area: "수도권",
+      environment: "카페작업",
+      bestSeason: "봄",
+    });
+
+    expect(client.calls.cities.eq).toEqual([
+      ["budget", "200만원 이상"],
+      ["area", "수도권"],
+    ]);
+    expect(client.calls.cities.contains).toEqual([
+      ["environment", ["카페작업"]],
+      ["best_season", ["봄"]],
+    ]);
+  });
+
+  it("forwards a custom limit", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: citiesWithWeather, error: null } },
+      },
+    });
+    setClient(client);
+
+    await getCities({}, 12);
+
+    expect(client.calls.cities.limit[0]).toEqual([12]);
+  });
+
+  it("returns an empty array when supabase returns null data", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: { select: { data: null, error: null } },
+      },
+    });
+    setClient(client);
+
+    await expect(getCities()).resolves.toEqual([]);
+  });
+
+  it("throws when supabase returns an error", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: {
+          select: { data: null, error: { message: "boom", code: "42P01" } },
+        },
+      },
+    });
+    setClient(client);
+
+    await expect(getCities()).rejects.toMatchObject({ message: "boom" });
+  });
+});
+
+describe("getCityById", () => {
+  it("returns the row for a given id via maybeSingle()", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: {
+          select: { data: [seoulWithWeather], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getCityById(seoulWithWeather.id);
+
+    expect(result).toEqual(seoulWithWeather);
+    expect(client.calls.cities.select[0][0]).toBe("*, city_weather(*)");
+    expect(client.calls.cities.eq).toEqual([["id", seoulWithWeather.id]]);
+    expect(client.calls.cities.maybeSingle).toEqual([[]]);
+  });
+
+  it("returns null when maybeSingle() yields no row", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: {
+          select: { data: [], error: null },
+        },
+      },
+    });
+    setClient(client);
+
+    const result = await getCityById("missing-id");
+
+    expect(result).toBeNull();
+    expect(client.calls.cities.eq).toEqual([["id", "missing-id"]]);
+  });
+
+  it("throws when supabase returns an error", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        cities: {
+          single: { data: null, error: { message: "nope" } },
+          select: { data: null, error: { message: "nope" } },
+        },
+      },
+    });
+    setClient(client);
+
+    await expect(getCityById("abc")).rejects.toMatchObject({ message: "nope" });
+  });
+});
+
+describe("getReviewsByCity", () => {
+  it("queries reviews with profiles join, filtered by city_id, ordered by created_at desc", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        reviews: { select: { data: reviews, error: null } },
+      },
+    });
+    setClient(client);
+
+    const result = await getReviewsByCity(
+      "11111111-1111-1111-1111-000000000001"
+    );
+
+    expect(result).toEqual(reviews);
+    expect(client.from).toHaveBeenCalledWith("reviews");
+    expect(client.calls.reviews.select[0][0]).toBe(
+      "*, profiles(username, avatar_url)"
+    );
+    expect(client.calls.reviews.eq).toEqual([
+      ["city_id", "11111111-1111-1111-1111-000000000001"],
+    ]);
+    expect(client.calls.reviews.order[0]).toEqual([
+      "created_at",
+      { ascending: false },
+    ]);
+    expect(client.calls.reviews.limit[0]).toEqual([20]);
+  });
+
+  it("honors a custom limit", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        reviews: { select: { data: reviews, error: null } },
+      },
+    });
+    setClient(client);
+
+    await getReviewsByCity("city-x", 3);
+
+    expect(client.calls.reviews.limit[0]).toEqual([3]);
+  });
+});
+
+describe("getRecentReviews", () => {
+  it("queries reviews with profiles + city join, ordered by created_at desc, default limit 6", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        reviews: { select: { data: reviews, error: null } },
+      },
+    });
+    setClient(client);
+
+    const result = await getRecentReviews();
+
+    expect(result).toEqual(reviews);
+    expect(client.calls.reviews.select[0][0]).toBe(
+      "*, profiles(username, avatar_url), city:cities(name_ko)"
+    );
+    expect(client.calls.reviews.order[0]).toEqual([
+      "created_at",
+      { ascending: false },
+    ]);
+    expect(client.calls.reviews.limit[0]).toEqual([6]);
+  });
+});
+
+describe("getPressQuotes", () => {
+  it("queries press_quotes ordered by display_order ascending", async () => {
+    const quotes = [
+      {
+        id: "pq-1",
+        quote: "Korea's Nomad List",
+        source: "KoreaHerald",
+        display_order: 1,
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ];
+    const client = makeSupabaseClient({
+      from: {
+        press_quotes: { select: { data: quotes, error: null } },
+      },
+    });
+    setClient(client);
+
+    const result = await getPressQuotes();
+
+    expect(result).toEqual(quotes);
+    expect(client.from).toHaveBeenCalledWith("press_quotes");
+    expect(client.calls.press_quotes.select[0][0]).toBe("*");
+    expect(client.calls.press_quotes.order[0]).toEqual([
+      "display_order",
+      { ascending: true },
+    ]);
+  });
+
+  it("returns an empty array when data is null", async () => {
+    const client = makeSupabaseClient({
+      from: {
+        press_quotes: { select: { data: null, error: null } },
+      },
+    });
+    setClient(client);
+
+    await expect(getPressQuotes()).resolves.toEqual([]);
+  });
+});
+
+describe("getCurrentUser", () => {
+  it("returns whatever supabase.auth.getUser resolves with", async () => {
+    const client = makeSupabaseClient({
+      auth: {
+        user: {
+          id: "user-42",
+          email: "user42@example.com",
+          user_metadata: { avatar_url: "https://example.com/42.png" },
+        },
+      },
+    });
+    setClient(client);
+
+    const user = await getCurrentUser();
+
+    expect(user).toEqual({
+      id: "user-42",
+      email: "user42@example.com",
+      user_metadata: { avatar_url: "https://example.com/42.png" },
+    });
+    expect(client.auth.getUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/lib/smoke.test.ts
+++ b/app/src/lib/smoke.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+
+// Removed once Phase 1 Round 1 lands real lib/* specs.
+describe("smoke", () => {
+  it("runs vitest with happy-dom + setup file wired", () => {
+    expect(typeof window).toBe("object");
+    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBe("https://test.supabase.co");
+  });
+});

--- a/app/src/lib/smoke.test.ts
+++ b/app/src/lib/smoke.test.ts
@@ -1,9 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-// Removed once Phase 1 Round 1 lands real lib/* specs.
-describe("smoke", () => {
-  it("runs vitest with happy-dom + setup file wired", () => {
-    expect(typeof window).toBe("object");
-    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBe("https://test.supabase.co");
-  });
-});

--- a/app/src/lib/vote-reducer.test.ts
+++ b/app/src/lib/vote-reducer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { voteReducer, type VoteState } from "./vote-reducer";
+
+function state(
+  vote: VoteState["vote"],
+  likeCount: number,
+  dislikeCount: number
+): VoteState {
+  return { vote, likeCount, dislikeCount };
+}
+
+describe("voteReducer - like action", () => {
+  it("vote=none 에서 like 는 likeCount +1 하고 vote=like 로 바꾼다", () => {
+    expect(voteReducer(state("none", 5, 3), "like")).toEqual(
+      state("like", 6, 3)
+    );
+  });
+
+  it("vote=like 에서 like 는 toggle off 로 동작해 likeCount -1, vote=none", () => {
+    expect(voteReducer(state("like", 5, 3), "like")).toEqual(
+      state("none", 4, 3)
+    );
+  });
+
+  it("vote=dislike 에서 like 는 dislikeCount -1, likeCount +1, vote=like", () => {
+    expect(voteReducer(state("dislike", 5, 3), "like")).toEqual(
+      state("like", 6, 2)
+    );
+  });
+});
+
+describe("voteReducer - dislike action", () => {
+  it("vote=none 에서 dislike 는 dislikeCount +1 하고 vote=dislike 로 바꾼다", () => {
+    expect(voteReducer(state("none", 5, 3), "dislike")).toEqual(
+      state("dislike", 5, 4)
+    );
+  });
+
+  it("vote=dislike 에서 dislike 는 toggle off 로 동작해 dislikeCount -1, vote=none", () => {
+    expect(voteReducer(state("dislike", 5, 3), "dislike")).toEqual(
+      state("none", 5, 2)
+    );
+  });
+
+  it("vote=like 에서 dislike 는 likeCount -1, dislikeCount +1, vote=dislike", () => {
+    expect(voteReducer(state("like", 5, 3), "dislike")).toEqual(
+      state("dislike", 4, 4)
+    );
+  });
+});
+
+describe("voteReducer - clear action", () => {
+  it("vote=like 에서 clear 는 likeCount -1, vote=none", () => {
+    expect(voteReducer(state("like", 5, 3), "clear")).toEqual(
+      state("none", 4, 3)
+    );
+  });
+
+  it("vote=dislike 에서 clear 는 dislikeCount -1, vote=none", () => {
+    expect(voteReducer(state("dislike", 5, 3), "clear")).toEqual(
+      state("none", 5, 2)
+    );
+  });
+
+  it("vote=none 에서 clear 는 카운트 변화 없이 그대로 vote=none", () => {
+    expect(voteReducer(state("none", 5, 3), "clear")).toEqual(
+      state("none", 5, 3)
+    );
+  });
+
+  it("vote=none 에서 clear 를 연속 호출해도 카운트가 음수가 되지 않는다", () => {
+    let s = state("none", 5, 3);
+    s = voteReducer(s, "clear");
+    s = voteReducer(s, "clear");
+    s = voteReducer(s, "clear");
+    expect(s).toEqual(state("none", 5, 3));
+  });
+});
+
+describe("voteReducer - immutability & misc", () => {
+  it("이전 상태 객체를 변이(mutate) 하지 않는다", () => {
+    const prev = state("like", 5, 3);
+    const snapshot = { ...prev };
+    voteReducer(prev, "like");
+    expect(prev).toEqual(snapshot);
+  });
+
+  it("like → clear 는 like → like 와 동일한 최종 상태를 만든다", () => {
+    const initial = state("like", 5, 3);
+    expect(voteReducer(initial, "clear")).toEqual(
+      voteReducer(initial, "like")
+    );
+  });
+
+  it("dislike → clear 는 dislike → dislike 와 동일한 최종 상태를 만든다", () => {
+    const initial = state("dislike", 5, 3);
+    expect(voteReducer(initial, "clear")).toEqual(
+      voteReducer(initial, "dislike")
+    );
+  });
+
+  it("like → dislike → like 전이가 카운트에 정확히 반영된다", () => {
+    let s = state("none", 10, 10);
+    s = voteReducer(s, "like");
+    expect(s).toEqual(state("like", 11, 10));
+    s = voteReducer(s, "dislike");
+    expect(s).toEqual(state("dislike", 10, 11));
+    s = voteReducer(s, "like");
+    expect(s).toEqual(state("like", 11, 10));
+  });
+});

--- a/app/test/fixtures/cities.ts
+++ b/app/test/fixtures/cities.ts
@@ -1,0 +1,117 @@
+import type {
+  CityRow,
+  CityWeatherRow,
+  CityWithWeather,
+} from "@/lib/database.types";
+
+const ISO = "2026-04-22T00:00:00.000Z";
+
+export const seoulRow: CityRow = {
+  id: "11111111-1111-1111-1111-000000000001",
+  name_ko: "서울",
+  name_en: "Seoul",
+  region: "수도권",
+  image_url: "https://example.com/seoul.jpg",
+  nomad_score: 4.5,
+  monthly_cost: 1850000,
+  internet_speed: 187,
+  safety_score: 4.6,
+  rank: 1,
+  budget: "200만원 이상",
+  area: "수도권",
+  tags: ["도심", "카페많음", "빠른인터넷"],
+  environment: ["도심선호", "카페작업", "코워킹 필수"],
+  best_season: ["봄", "가을"],
+  review_count: 0,
+  like_count: 245,
+  dislike_count: 18,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+export const busanRow: CityRow = {
+  id: "11111111-1111-1111-1111-000000000002",
+  name_ko: "부산",
+  name_en: "Busan",
+  region: "영남권",
+  image_url: "https://example.com/busan.jpg",
+  nomad_score: 4.3,
+  monthly_cost: 1200000,
+  internet_speed: 156,
+  safety_score: 4.4,
+  rank: 2,
+  budget: "100~200만원",
+  area: "경상도",
+  tags: ["해변", "맛집많음"],
+  environment: ["카페작업", "자연친화"],
+  best_season: ["봄", "가을"],
+  review_count: 0,
+  like_count: 198,
+  dislike_count: 12,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+export const gangneungRow: CityRow = {
+  id: "11111111-1111-1111-1111-000000000005",
+  name_ko: "강릉",
+  name_en: "Gangneung",
+  region: "강원권",
+  image_url: "https://example.com/gangneung.jpg",
+  nomad_score: 4.0,
+  monthly_cost: 980000,
+  internet_speed: 165,
+  safety_score: 4.6,
+  rank: 5,
+  budget: "100만원 이하",
+  area: "강원도",
+  tags: ["해변", "자연"],
+  environment: ["자연친화", "카페작업"],
+  best_season: ["여름", "가을"],
+  review_count: 0,
+  like_count: 72,
+  dislike_count: 9,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+export const seoulWeather: CityWeatherRow = {
+  city_id: seoulRow.id,
+  current_temp: 9,
+  weather_emoji: "☀️",
+  aqi: 72,
+  observed_at: ISO,
+};
+
+export const seoulWithWeather: CityWithWeather = {
+  ...seoulRow,
+  city_weather: seoulWeather,
+};
+
+export const busanWithWeather: CityWithWeather = {
+  ...busanRow,
+  city_weather: {
+    city_id: busanRow.id,
+    current_temp: 12,
+    weather_emoji: "☀️",
+    aqi: 45,
+    observed_at: ISO,
+  },
+};
+
+export const gangneungWithWeather: CityWithWeather = {
+  ...gangneungRow,
+  city_weather: {
+    city_id: gangneungRow.id,
+    current_temp: 5,
+    weather_emoji: "🌤",
+    aqi: 28,
+    observed_at: ISO,
+  },
+};
+
+export const citiesWithWeather: CityWithWeather[] = [
+  seoulWithWeather,
+  busanWithWeather,
+  gangneungWithWeather,
+];

--- a/app/test/fixtures/profiles.ts
+++ b/app/test/fixtures/profiles.ts
@@ -1,0 +1,19 @@
+import type { ProfileRow } from "@/lib/database.types";
+import type { AuthUser } from "@/../test/helpers/supabase-mock";
+
+const ISO = "2026-04-20T09:00:00.000Z";
+
+export const authUser: AuthUser = {
+  id: "user-1",
+  email: "alex@example.com",
+  user_metadata: { avatar_url: "https://example.com/alex.png" },
+};
+
+export const profileRow: ProfileRow = {
+  id: authUser.id,
+  username: "alex_nomad",
+  avatar_url: "https://example.com/alex.png",
+  current_city_id: null,
+  created_at: ISO,
+  updated_at: ISO,
+};

--- a/app/test/fixtures/reviews.ts
+++ b/app/test/fixtures/reviews.ts
@@ -1,0 +1,41 @@
+import type { ReviewRow } from "@/lib/database.types";
+
+const ISO = "2026-04-20T09:00:00.000Z";
+
+export interface ReviewWithAuthorFixture extends ReviewRow {
+  profiles: { username: string | null; avatar_url: string | null } | null;
+}
+
+export const seoulReview: ReviewWithAuthorFixture = {
+  id: "aaaaaaaa-0000-0000-0000-000000000001",
+  user_id: "user-1",
+  city_id: "11111111-1111-1111-1111-000000000001",
+  rating: 5,
+  stay_duration: "3개월 체류",
+  content: "강남역 근처 코워킹 스페이스가 정말 많고 인터넷도 빨라서 일하기 좋았습니다.",
+  pros: ["빠른인터넷", "카페많음"],
+  cons: ["비싼월세"],
+  like_count: 24,
+  comment_count: 3,
+  created_at: ISO,
+  updated_at: ISO,
+  profiles: { username: "alex_nomad", avatar_url: null },
+};
+
+export const jejuReview: ReviewWithAuthorFixture = {
+  id: "aaaaaaaa-0000-0000-0000-000000000002",
+  user_id: "user-2",
+  city_id: "11111111-1111-1111-1111-000000000003",
+  rating: 4,
+  stay_duration: "1~4주 체류",
+  content: "자연환경 좋고 카페 예쁨. 렌터카 없이는 이동이 좀 불편해요.",
+  pros: ["자연환경", "카페많음"],
+  cons: ["대중교통불편"],
+  like_count: 18,
+  comment_count: 5,
+  created_at: "2026-04-15T09:00:00.000Z",
+  updated_at: "2026-04-15T09:00:00.000Z",
+  profiles: { username: "mina_travels", avatar_url: null },
+};
+
+export const reviews: ReviewWithAuthorFixture[] = [seoulReview, jejuReview];

--- a/app/test/helpers/next-mocks.ts
+++ b/app/test/helpers/next-mocks.ts
@@ -3,17 +3,38 @@ import { vi } from "vitest";
 /**
  * Shared next/* module stubs.
  *
- * Import and call `installNextMocks()` inside a `beforeEach` (or at the top of
- * a test file) when you need to observe/assert against redirects, path
- * revalidations, cookie jars, or header maps.
+ * Vitest hoists `vi.mock(...)` calls above ESM imports, so **importing a
+ * factory statically and passing it to `vi.mock(name, factory)` throws
+ * `Cannot access '__vi_import_0__' before initialization`**. Instead, wrap
+ * the factory in an async import inside the vi.mock callback so the helper
+ * is resolved at call time:
  *
- * Example:
- *   import { installNextMocks } from "@/../test/helpers/next-mocks";
+ *   vi.mock("next/navigation", async () => {
+ *     const { nextNavigationFactory } = await import(
+ *       "../../../test/helpers/next-mocks"
+ *     );
+ *     return nextNavigationFactory();
+ *   });
+ *   vi.mock("next/cache", async () => {
+ *     const { nextCacheFactory } = await import(
+ *       "../../../test/helpers/next-mocks"
+ *     );
+ *     return nextCacheFactory();
+ *   });
+ *   vi.mock("next/headers", async () => {
+ *     const { nextHeadersFactory } = await import(
+ *       "../../../test/helpers/next-mocks"
+ *     );
+ *     return nextHeadersFactory();
+ *   });
  *
- *   const { redirect, revalidatePath, headersMap } = installNextMocks();
- *   redirect.mockClear();
- *   ...
- *   expect(redirect).toHaveBeenCalledWith("/login?error=...");
+ * Then in your tests read/clear the shared state through `getNextMockState`
+ * and `resetNextMocks` (see below):
+ *
+ *   beforeEach(() => resetNextMocks());
+ *   expect(getNextMockState().redirect).toHaveBeenCalledWith(
+ *     "/login?error=..."
+ *   );
  */
 
 interface InstalledMocks {

--- a/app/test/helpers/next-mocks.ts
+++ b/app/test/helpers/next-mocks.ts
@@ -1,0 +1,114 @@
+import { vi } from "vitest";
+
+/**
+ * Shared next/* module stubs.
+ *
+ * Import and call `installNextMocks()` inside a `beforeEach` (or at the top of
+ * a test file) when you need to observe/assert against redirects, path
+ * revalidations, cookie jars, or header maps.
+ *
+ * Example:
+ *   import { installNextMocks } from "@/../test/helpers/next-mocks";
+ *
+ *   const { redirect, revalidatePath, headersMap } = installNextMocks();
+ *   redirect.mockClear();
+ *   ...
+ *   expect(redirect).toHaveBeenCalledWith("/login?error=...");
+ */
+
+interface InstalledMocks {
+  redirect: ReturnType<typeof vi.fn>;
+  revalidatePath: ReturnType<typeof vi.fn>;
+  notFound: ReturnType<typeof vi.fn>;
+  headersMap: Map<string, string>;
+  cookieJar: Map<string, string>;
+}
+
+const state: InstalledMocks = {
+  redirect: vi.fn((url: string) => {
+    throw Object.assign(new Error(`NEXT_REDIRECT:${url}`), {
+      digest: `NEXT_REDIRECT;replace;${url};307;`,
+    });
+  }),
+  revalidatePath: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  headersMap: new Map<string, string>(),
+  cookieJar: new Map<string, string>(),
+};
+
+/**
+ * Call `vi.mock("next/navigation", ...)` / `vi.mock("next/cache", ...)` /
+ * `vi.mock("next/headers", ...)` with this factory at the top of your test
+ * file (vi.mock is hoisted so it must be at module scope).
+ *
+ * This helper returns the shared state so you can read/clear between tests.
+ */
+export function getNextMockState(): InstalledMocks {
+  return state;
+}
+
+export function nextNavigationFactory() {
+  return {
+    redirect: state.redirect,
+    notFound: state.notFound,
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => "/",
+  };
+}
+
+export function nextCacheFactory() {
+  return {
+    revalidatePath: state.revalidatePath,
+    revalidateTag: vi.fn(),
+    unstable_noStore: vi.fn(),
+  };
+}
+
+export function nextHeadersFactory() {
+  const headersProxy = {
+    get: (key: string) => state.headersMap.get(key.toLowerCase()) ?? null,
+    has: (key: string) => state.headersMap.has(key.toLowerCase()),
+    forEach: (cb: (value: string, key: string) => void) => {
+      state.headersMap.forEach(cb);
+    },
+    entries: () => state.headersMap.entries(),
+  };
+  const cookiesProxy = {
+    get: (name: string) => {
+      const v = state.cookieJar.get(name);
+      return v == null ? undefined : { name, value: v };
+    },
+    getAll: () =>
+      Array.from(state.cookieJar.entries()).map(([name, value]) => ({
+        name,
+        value,
+      })),
+    has: (name: string) => state.cookieJar.has(name),
+    set: (name: string, value: string) => {
+      state.cookieJar.set(name, value);
+    },
+    delete: (name: string) => state.cookieJar.delete(name),
+  };
+  return {
+    headers: async () => headersProxy,
+    cookies: async () => cookiesProxy,
+  };
+}
+
+export function resetNextMocks() {
+  state.redirect.mockClear();
+  state.revalidatePath.mockClear();
+  state.notFound.mockClear();
+  state.headersMap.clear();
+  state.cookieJar.clear();
+}

--- a/app/test/helpers/render.tsx
+++ b/app/test/helpers/render.tsx
@@ -1,0 +1,16 @@
+import { render as rtlRender, type RenderOptions } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+
+/**
+ * Custom render that sets up a `user` helper alongside RTL.
+ * No providers required right now; wrap here when we add context later.
+ */
+export function render(ui: ReactElement, options?: RenderOptions) {
+  return {
+    user: userEvent.setup(),
+    ...rtlRender(ui, options),
+  };
+}
+
+export * from "@testing-library/react";

--- a/app/test/helpers/supabase-mock.ts
+++ b/app/test/helpers/supabase-mock.ts
@@ -1,0 +1,227 @@
+import { vi, type Mock } from "vitest";
+
+/**
+ * Chainable Postgrest builder stub. Every filter/modifier method on
+ * PostgrestQueryBuilder/PostgrestFilterBuilder returns `this` (the same
+ * builder), so we build one proxy that returns itself for unknown keys and
+ * resolves to the queued result when awaited, called as `.single()`, or
+ * passed to `Promise.resolve`.
+ *
+ * Usage:
+ *   const supabase = makeSupabaseClient({
+ *     from: {
+ *       cities: { select: { data: cityRows, error: null } },
+ *       city_votes: { select: { data: [], error: null } },
+ *     },
+ *   });
+ *
+ *   vi.mock("@/utils/supabase/server", () => ({
+ *     createClient: vi.fn().mockResolvedValue(supabase),
+ *   }));
+ */
+
+export interface QueryResult<T = unknown> {
+  data: T | null;
+  error: { message: string; code?: string } | null;
+  count?: number | null;
+  status?: number;
+  statusText?: string;
+}
+
+type TableStubs = Partial<{
+  select: QueryResult | (() => QueryResult);
+  insert: QueryResult | (() => QueryResult);
+  upsert: QueryResult | (() => QueryResult);
+  update: QueryResult | (() => QueryResult);
+  delete: QueryResult | (() => QueryResult);
+  /** Overrides for `.single()` / `.maybeSingle()` (defaults to `select[0]`) */
+  single: QueryResult | (() => QueryResult);
+}>;
+
+export interface FromConfig {
+  [tableName: string]: TableStubs;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string | null;
+  user_metadata?: Record<string, unknown>;
+}
+
+export interface AuthConfig {
+  user?: AuthUser | null;
+  session?: unknown;
+  getUserError?: { message: string } | null;
+  signInWithOAuth?: QueryResult<{ url: string; provider: string }>;
+  signInWithPassword?: QueryResult;
+  signUp?: QueryResult;
+  signOut?: QueryResult;
+  exchangeCodeForSession?: QueryResult;
+  verifyOtp?: QueryResult;
+}
+
+export interface SupabaseClientMock {
+  from: Mock;
+  auth: {
+    getUser: Mock;
+    signInWithOAuth: Mock;
+    signInWithPassword: Mock;
+    signUp: Mock;
+    signOut: Mock;
+    exchangeCodeForSession: Mock;
+    verifyOtp: Mock;
+    role?: Mock;
+  };
+  /** Recorded calls per-table per-method for assertions. */
+  calls: Record<string, Record<string, unknown[][]>>;
+  /** Convenience: last `.select()` argument passed to a given table. */
+  lastSelect(table: string): unknown | undefined;
+  /** Convenience: last `.insert()` / `.upsert()` payload. */
+  lastWrite(table: string): unknown | undefined;
+}
+
+function resolveResult(
+  stub: TableStubs[keyof TableStubs] | undefined,
+  fallback: QueryResult = { data: null, error: null }
+): QueryResult {
+  if (!stub) return fallback;
+  return typeof stub === "function" ? stub() : stub;
+}
+
+/** Build a chainable builder whose every method returns itself. */
+function buildBuilder(
+  table: string,
+  stubs: TableStubs | undefined,
+  record: (method: string, args: unknown[]) => void
+): unknown {
+  let activeMethod: keyof TableStubs = "select";
+
+  const target = {
+    then(
+      onFulfilled?: (value: QueryResult) => unknown,
+      onRejected?: (reason: unknown) => unknown
+    ) {
+      const result = resolveResult(stubs?.[activeMethod]);
+      return Promise.resolve(result).then(onFulfilled, onRejected);
+    },
+    catch(onRejected: (reason: unknown) => unknown) {
+      return Promise.resolve(resolveResult(stubs?.[activeMethod])).catch(
+        onRejected
+      );
+    },
+  };
+
+  const handler: ProxyHandler<typeof target> = {
+    get(_t, prop: string | symbol) {
+      if (prop === "then") return target.then;
+      if (prop === "catch") return target.catch;
+      if (prop === "finally") return undefined;
+      if (typeof prop !== "string") return undefined;
+
+      // Writing methods switch which stub `then` resolves with.
+      if (
+        prop === "select" ||
+        prop === "insert" ||
+        prop === "upsert" ||
+        prop === "update" ||
+        prop === "delete"
+      ) {
+        return (...args: unknown[]) => {
+          activeMethod = prop as keyof TableStubs;
+          record(prop, args);
+          return proxy;
+        };
+      }
+
+      if (prop === "single" || prop === "maybeSingle") {
+        return () => {
+          record(prop, []);
+          const override = stubs?.single;
+          if (override) {
+            return Promise.resolve(resolveResult(override));
+          }
+          const current = resolveResult(stubs?.[activeMethod]);
+          const single =
+            Array.isArray(current.data) && current.data.length > 0
+              ? { ...current, data: current.data[0] }
+              : prop === "maybeSingle"
+              ? { ...current, data: null }
+              : current;
+          return Promise.resolve(single);
+        };
+      }
+
+      // Default: any other method (eq/gt/lt/order/limit/contains/in/is/…)
+      // just records and returns the proxy.
+      return (...args: unknown[]) => {
+        record(prop, args);
+        return proxy;
+      };
+    },
+  };
+
+  const proxy: unknown = new Proxy(target, handler);
+  // Tag builder with table name for debugging.
+  Object.defineProperty(proxy, "__table", { value: table });
+  return proxy;
+}
+
+export function makeSupabaseClient(config: {
+  from?: FromConfig;
+  auth?: AuthConfig;
+} = {}): SupabaseClientMock {
+  const calls: SupabaseClientMock["calls"] = {};
+
+  const record = (table: string, method: string, args: unknown[]) => {
+    calls[table] ??= {};
+    calls[table][method] ??= [];
+    calls[table][method].push(args);
+  };
+
+  const from = vi.fn((table: string) => {
+    calls[table] ??= {};
+    return buildBuilder(table, config.from?.[table], (method, args) =>
+      record(table, method, args)
+    );
+  });
+
+  const auth = {
+    getUser: vi.fn(async () => ({
+      data: {
+        user: config.auth?.user ?? null,
+      },
+      error: config.auth?.getUserError ?? null,
+    })),
+    signInWithOAuth: vi.fn(async () =>
+      resolveResult(config.auth?.signInWithOAuth) as QueryResult<{
+        url: string;
+        provider: string;
+      }>
+    ),
+    signInWithPassword: vi.fn(async () =>
+      resolveResult(config.auth?.signInWithPassword)
+    ),
+    signUp: vi.fn(async () => resolveResult(config.auth?.signUp)),
+    signOut: vi.fn(async () => resolveResult(config.auth?.signOut)),
+    exchangeCodeForSession: vi.fn(async () =>
+      resolveResult(config.auth?.exchangeCodeForSession)
+    ),
+    verifyOtp: vi.fn(async () => resolveResult(config.auth?.verifyOtp)),
+  };
+
+  return {
+    from,
+    auth,
+    calls,
+    lastSelect(table) {
+      return calls[table]?.select?.at(-1)?.[0];
+    },
+    lastWrite(table) {
+      return (
+        calls[table]?.insert?.at(-1)?.[0] ??
+        calls[table]?.upsert?.at(-1)?.[0] ??
+        calls[table]?.update?.at(-1)?.[0]
+      );
+    },
+  };
+}

--- a/app/test/stubs/server-only.ts
+++ b/app/test/stubs/server-only.ts
@@ -1,0 +1,4 @@
+// Empty stub for Next.js `server-only` marker package used under Vitest.
+// See vitest.config.ts `resolve.alias` for the TODO tracking when this can
+// be dropped.
+export {};

--- a/app/tests-e2e/auth.spec.ts
+++ b/app/tests-e2e/auth.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("/login page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("renders 로그인 heading", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "로그인" })).toBeVisible();
+  });
+
+  test("shows email/password inputs, 로그인 submit, Google button, and 회원가입 link", async ({
+    page,
+  }) => {
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+
+    // The main form's 로그인 submit button (inside main content, not navbar)
+    const submit = page
+      .locator("main")
+      .getByRole("button", { name: "로그인", exact: true });
+    await expect(submit).toBeVisible();
+
+    // Google continue button
+    await expect(
+      page.getByRole("button", { name: /Google로 계속하기/ })
+    ).toBeVisible();
+
+    // 회원가입 link (body CTA, not nav — use 'link' role)
+    await expect(
+      page.getByRole("link", { name: "회원가입" }).first()
+    ).toBeVisible();
+  });
+});
+
+test.describe("/register page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/register");
+  });
+
+  test("renders 회원가입 heading", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "회원가입" })
+    ).toBeVisible();
+  });
+
+  test("shows email/password inputs, 가입하기 submit, Google button, and 로그인 link", async ({
+    page,
+  }) => {
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "가입하기" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Google로 계속하기/ })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "로그인" }).first()
+    ).toBeVisible();
+  });
+});
+
+test.describe("navbar auth state (logged-out)", () => {
+  test("desktop: shows 로그인 + 회원가입 buttons in nav", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+
+    const nav = page.locator("nav").first();
+    await expect(nav.getByRole("link", { name: "로그인" })).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: /회원가입/ })
+    ).toBeVisible();
+  });
+
+  test("mobile: hamburger visible, clicking opens menu", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+
+    const hamburger = page.getByRole("button", { name: "메뉴 열기" });
+    await expect(hamburger).toBeVisible();
+
+    // Mobile menu links are hidden until hamburger is clicked.
+    await hamburger.click();
+
+    // After opening, both 로그인 and 회원가입 links should render within the nav.
+    const nav = page.locator("nav").first();
+    await expect(nav.getByRole("link", { name: "로그인" })).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: "회원가입" })
+    ).toBeVisible();
+  });
+});

--- a/app/tests-e2e/city-detail.spec.ts
+++ b/app/tests-e2e/city-detail.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+const SEOUL_ID = "11111111-1111-1111-1111-000000000001";
+const MISSING_ID = "00000000-0000-0000-0000-000000000999";
+
+test.describe("city detail page — Seoul", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/city/${SEOUL_ID}`);
+  });
+
+  test("renders 서울 (Seoul) heading", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: /서울[\s\S]*Seoul/ })
+    ).toBeVisible();
+  });
+
+  test("metric cards are visible", async ({ page }) => {
+    await expect(page.getByText("월 생활비")).toBeVisible();
+    await expect(page.getByText("인터넷", { exact: true })).toBeVisible();
+    await expect(page.getByText("안전 점수")).toBeVisible();
+    await expect(page.getByText("현재 날씨")).toBeVisible();
+    await expect(page.getByText("공기질(AQI)")).toBeVisible();
+  });
+
+  test("has back-to-home link", async ({ page }) => {
+    const backLink = page.getByRole("link", { name: /← 홈으로 돌아가기/ });
+    await expect(backLink).toBeVisible();
+  });
+
+  test("renders city tag pills", async ({ page }) => {
+    // seed: ['도심','카페많음','빠른인터넷','외국인친화']
+    await expect(page.getByText("도심", { exact: true }).first()).toBeVisible();
+    await expect(
+      page.getByText("카페많음", { exact: true }).first()
+    ).toBeVisible();
+  });
+
+  test("리뷰 section exists with empty state", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "리뷰" })).toBeVisible();
+    // Seed has no reviews for Seoul, so empty state renders
+    await expect(page.getByText("아직 리뷰가 없습니다")).toBeVisible();
+  });
+});
+
+test.describe("city detail page — missing id", () => {
+  test("responds with 404 / not-found for an unknown id", async ({ page }) => {
+    const response = await page.goto(`/city/${MISSING_ID}`);
+    // Next.js notFound() returns a 404 status for the document
+    expect(response?.status()).toBe(404);
+    // Default 404 contains "404" or "This page could not be found"
+    await expect(
+      page.getByText(/404|This page could not be found|Not Found/i).first()
+    ).toBeVisible();
+  });
+});

--- a/app/tests-e2e/filter.spec.ts
+++ b/app/tests-e2e/filter.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, Page } from "@playwright/test";
+
+/**
+ * Open the Select combobox associated with a given label (예산/지역/환경/최고 계절)
+ * and click the option with the given label.
+ *
+ * The Select component (base-ui) renders a button-like trigger with
+ * data-slot="select-trigger". The label is the sibling <label> element — we
+ * locate the containing wrapper via `:has(label)` and reach the trigger inside.
+ */
+async function selectOption(page: Page, label: string, option: string) {
+  const trigger = page
+    .locator(`div.space-y-1:has(label:text-is("${label}"))`)
+    .locator('[data-slot="select-trigger"]');
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  // base-ui renders items in a portal; target the list that is currently open.
+  const openList = page.locator(
+    '[data-slot="select-content"][data-open], [data-slot="select-content"]'
+  );
+  const item = openList
+    .locator('[data-slot="select-item"]')
+    .filter({ hasText: new RegExp(`^${escapeRegExp(option)}$`) });
+  await item.first().click();
+}
+
+function escapeRegExp(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+test.describe("filter bar", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("selecting 강원도 narrows cards and adds region query", async ({
+    page,
+  }) => {
+    await selectOption(page, "지역", "강원도");
+
+    await page.waitForURL(/region=%EA%B0%95%EC%9B%90%EB%8F%84|region=강원도/);
+    expect(decodeURIComponent(page.url())).toContain("region=강원도");
+
+    // Seed: 강릉, 춘천, 속초 → 3 cities in 강원도
+    const cards = page.locator('a[href^="/city/"]');
+    await expect.poll(async () => await cards.count()).toBeLessThanOrEqual(5);
+    expect(await cards.count()).toBeGreaterThanOrEqual(1);
+
+    // Specific 강원도 city should appear
+    await expect(page.getByText(/강릉|춘천|속초/).first()).toBeVisible();
+  });
+
+  test("adding 예산 filter preserves region param", async ({ page }) => {
+    await selectOption(page, "지역", "강원도");
+    await page.waitForURL(/region=/);
+
+    await selectOption(page, "예산", "100만원 이하");
+    await page.waitForURL(/budget=/);
+
+    // URLSearchParams decodes both %20 and + to spaces, whereas
+    // decodeURIComponent leaves '+' alone. Use the parser so the assertion
+    // is invariant to which form the router picks.
+    const params = new URL(page.url()).searchParams;
+    expect(params.get("region")).toBe("강원도");
+    expect(params.get("budget")).toBe("100만원 이하");
+  });
+
+  test("choosing 전체 removes that filter param", async ({ page }) => {
+    await selectOption(page, "지역", "강원도");
+    await page.waitForURL(/region=/);
+
+    await selectOption(page, "지역", "전체");
+    await page.waitForURL((url) => !url.search.includes("region="));
+
+    expect(page.url()).not.toContain("region=");
+  });
+});

--- a/app/tests-e2e/home.spec.ts
+++ b/app/tests-e2e/home.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("home page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("renders hero heading", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: /대한민국에서[\s\S]*노마드하기/ })
+    ).toBeVisible();
+  });
+
+  test("renders at least 12 city cards", async ({ page }) => {
+    const cityLinks = page.locator('a[href^="/city/"]');
+    await expect(cityLinks.first()).toBeVisible();
+    expect(await cityLinks.count()).toBeGreaterThanOrEqual(12);
+  });
+
+  test("first card has rank badge, Seoul text, Mbps and ₩ cost", async ({
+    page,
+  }) => {
+    const firstCard = page.locator('a[href^="/city/"]').first();
+    await expect(firstCard).toBeVisible();
+
+    // Rank #1 badge
+    await expect(firstCard.getByText("#1", { exact: true })).toBeVisible();
+    // Korean 서울 + English (Seoul)
+    await expect(firstCard.getByText(/서울/)).toBeVisible();
+    await expect(firstCard.getByText(/Seoul/)).toBeVisible();
+    // Internet speed in Mbps
+    await expect(firstCard.getByText(/Mbps/)).toBeVisible();
+    // Cost with ₩ symbol
+    await expect(firstCard.getByText(/₩[\d,]+/)).toBeVisible();
+  });
+
+  test("first card shows weather emoji, °C temp, and AQI", async ({ page }) => {
+    const firstCard = page.locator('a[href^="/city/"]').first();
+    // Weather block contains emoji + °C
+    await expect(firstCard.getByText(/°C/)).toBeVisible();
+    // AQI block
+    await expect(firstCard.getByText(/AQI\s+\d+/)).toBeVisible();
+    // At least one known weather emoji ☀️, 🌧, or 🌤
+    const weatherText = await firstCard.innerText();
+    expect(weatherText).toMatch(/[☀️🌧🌤]/u);
+  });
+
+  test("shows 도시 리스트 heading and 더 많은 도시 보기 button", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("heading", { name: "도시 리스트" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /더 많은 도시 보기/ })
+    ).toBeVisible();
+  });
+});

--- a/app/tests-e2e/playwright.config.ts
+++ b/app/tests-e2e/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.E2E_PORT ?? "3111";
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["github"]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      // TODO(test-setup): `server-only` is Next.js' client-component guard. Under
+      // Vitest we need to alias it to an empty stub so modules that `import
+      // "server-only"` (lib/queries.ts, lib/current-user.ts, app/actions/*)
+      // can load. Remove this alias once the setup branch adds a shared stub.
+      "server-only": path.resolve(__dirname, "./test/stubs/server-only.ts"),
+    },
+  },
   test: {
     environment: "happy-dom",
     globals: true,

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["node_modules", ".next", "tests-e2e/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: [
+        "src/lib/**/*.ts",
+        "src/app/actions/**/*.ts",
+        "src/app/login/actions.ts",
+        "src/app/auth/**/route.ts",
+        "src/components/sections/**/*.tsx",
+      ],
+      exclude: [
+        "src/lib/database.types.ts",
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.spec.{ts,tsx}",
+      ],
+    },
+  },
+});

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -1,0 +1,13 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Reset DOM + any module-level mocks between tests
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Stable defaults for env-driven code paths (overridden per-test when needed)
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";


### PR DESCRIPTION
## Summary
- Full test suite: **132 Vitest specs across 15 files** + **20 Playwright E2E specs across 4 files**, all green locally.
- Covers every lib helper, every server action, both auth route handlers, and every user-visible client component; Playwright exercises the home/detail/filter/auth pages against the real Supabase-backed dev server in read-only mode.
- Built in the Phase 0 → 4+3 parallel agents → Phase 2 integration pattern outlined in the prior plan; 7 agents across 2 rounds worked in isolated git worktrees so there were zero file-level conflicts.

## Commits (9)
1. `chore(test): add Vitest + RTL + Playwright infrastructure` — config, helpers, fixtures, dev deps, smoke spec
2. `chore(test): alias server-only to a stub and document next-mocks hoisting` — fixes Vitest's `Cannot access '__vi_import_0__'` trap
3. `test(lib): unit tests for filters, format, vote-reducer, queries, current-user` — 65 specs
4. `test(actions): server action tests with Supabase/Next mocks` — 17 specs
5. `test(routes): auth callback and confirm route handler tests` — 10 specs
6. `test(ui): RTL tests for Navbar, Hero, FilterBar` — 19 specs
7. `test(ui): RTL tests for CityCard and CityGrid` — 19 specs
8. `test(e2e): Playwright specs for home, city detail, filter, and auth` — 19 specs + gitignore artifacts
9. `chore(test): remove smoke test now that real specs cover the harness`

## How to run
```bash
cd app
npm test                 # vitest run  → 15 files, 132 tests
npm run test:watch       # interactive
npm run test:coverage    # v8 coverage report

npx playwright install chromium   # first run only
npm run test:e2e                  # Playwright → 20 tests
```

## Test breakdown

**Vitest (132 tests)**
| Area | Files | Tests |
|---|---|---|
| lib (pure logic + queries) | filters / format / vote-reducer / queries / current-user | 65 |
| server actions | city-vote / sign-out / login(actions) | 17 |
| route handlers | auth/callback / auth/confirm | 10 |
| client components | navbar / hero / filter-bar / city-card / city-grid | 40 |

**Playwright (20 tests)**
| Spec | Scenarios |
|---|---|
| home.spec.ts | hero heading, 12+ cards, first-card content, weather/AQI, list heading/load-more |
| city-detail.spec.ts | Seoul heading, metric cards, back link, tag pills, empty reviews, 404 |
| filter.spec.ts | 강원도 narrowing + region param, 예산 adding preserves region, 전체 removes param |
| auth.spec.ts | /login + /register composition (incl. Google button), desktop navbar, mobile hamburger |

## Infrastructure notes
- **Supabase mock** (`test/helpers/supabase-mock.ts`): chainable Postgrest proxy that returns itself for any filter method and resolves stubbed `QueryResult`s on `.then` / `.single` / `.maybeSingle`, with per-table call recording for shape assertions.
- **Next stubs** (`test/helpers/next-mocks.ts`): factories for `next/navigation`, `next/cache`, `next/headers` — importable *lazily* inside `vi.mock(name, async () => (await import(...))...)` because vitest hoists mock calls above ESM imports.
- **`server-only` alias** (`test/stubs/server-only.ts` via `vitest.config.ts` `resolve.alias`): lets `lib/queries.ts`, `lib/current-user.ts`, and server-action modules load under Vite without tripping Next's client-guard throw.
- **Fixtures** (`test/fixtures/{cities,reviews,profiles}.ts`): typed sample rows used across specs so every test speaks the same domain shape.

## Known follow-ups (not fixed in this PR)
- **CityCard optimistic counts**: the current source calls `startTransition(() => { mutate(d); voteCity(...) })` without `await`-ing the action's promise, so React 19's `useOptimistic` pending-value never sticks in practice. `city-card.test.tsx` has a top-of-file TODO describing the one-line fix (`startTransition(async () => { mutate(d); await voteCity(...); })`) which would let the spec assert on mid-flight optimistic counts/styles in addition to the call arguments already verified.
- **Sidebar server component**: async server component with nested Supabase joins; we left it to the E2E layer instead of attempting to render it under RTL.
- **Google OAuth E2E**: only the button/redirect initiation is asserted — actually completing Google's consent screen is flaky in automation.
- Vitest 4.1 warns that `vite-tsconfig-paths` is redundant with Vite's native `resolve.tsconfigPaths`. Can be switched in a small follow-up; left alone so this PR does not touch infra unnecessarily.

## Test plan
- [ ] `cd app && npm test` → 15 files / 132 passed
- [ ] `cd app && npm run test:e2e` → 20 passed (needs `npx playwright install chromium` first time)
- [ ] `cd app && npx next build` → still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)