### PR TITLE
fix + chore: optimistic-vote fix and Vite plugin cleanup

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -36,7 +36,6 @@
         "happy-dom": "^20.9.0",
         "tailwindcss": "^4",
         "typescript": "^5",
-        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.5"
       }
     },
@@ -6299,13 +6298,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10311,27 +10303,6 @@
         "code-block-writer": "^13.0.3"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10779,21 +10750,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,6 @@
     "happy-dom": "^20.9.0",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.5"
   }
 }

--- a/app/src/components/sections/city-card.test.tsx
+++ b/app/src/components/sections/city-card.test.tsx
@@ -13,19 +13,12 @@ import {
 import type { CityWithWeather } from "@/lib/database.types";
 import { CityCard } from "./city-card";
 
-// TODO(city-card-optimistic): `useOptimistic` only persists its optimistic
-// value while the enclosing action is in-flight. The current source wraps
-// `mutate(...)` + `voteCity(...)` in a *synchronous* `startTransition(() =>
-// {...})` callback that does NOT `return`/`await` the `voteCity(...)`
-// promise, so React treats the action as "complete" in the same tick and
-// reverts the optimistic state before any render commits with the new
-// counts. That means we cannot observe `likeCount + 1` / `dislikeCount - 1`
-// from the DOM in this test environment. When the source is updated to
-// return or await the server-action promise from inside `startTransition`
-// (or is refactored to `useActionState`), these tests should be expanded to
-// also assert the optimistic count / active-vote styling after the click.
-// For now we assert the dispatched `voteCity(...)` call — which is the
-// behavior we can verify without touching the source.
+// To observe `useOptimistic`'s mutated state the action must actually be
+// pending — once it resolves React reverts to the canonical value. Tests
+// that need to check the mid-flight count install a "hanging" promise with
+// `voteCityMock.mockReturnValueOnce(new Promise(() => {}))`; the other
+// tests keep the default `mockResolvedValue(undefined)` and assert on the
+// dispatched call.
 
 describe("<CityCard />", () => {
   beforeEach(() => {
@@ -198,6 +191,60 @@ describe("<CityCard />", () => {
     });
     expect(link?.getAttribute("href")).toBe(`/city/${seoulWithWeather.id}`);
     expect(link?.isConnected).toBe(true);
+  });
+
+  it("shows optimistic like count + active style while voteCity is pending (none → like)", async () => {
+    voteCityMock.mockReturnValueOnce(new Promise<void>(() => {}));
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="none" />
+    );
+
+    const expected = String(seoulWithWeather.like_count + 1);
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+    const likeBtn = screen.getByRole("button", { name: "👍" });
+    expect(likeBtn.className).toMatch(/text-blue-600/);
+  });
+
+  it("optimistically decrements the like count when toggling off (like → clear)", async () => {
+    voteCityMock.mockReturnValueOnce(new Promise<void>(() => {}));
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="like" />
+    );
+
+    const expected = String(seoulWithWeather.like_count - 1);
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+    const likeBtn = screen.getByRole("button", { name: "👍" });
+    expect(likeBtn.className).not.toMatch(/text-blue-600/);
+  });
+
+  it("optimistically swaps counts when switching from dislike to like", async () => {
+    voteCityMock.mockReturnValueOnce(new Promise<void>(() => {}));
+    const { user } = render(
+      <CityCard city={seoulWithWeather} initialVote="dislike" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "👍" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(String(seoulWithWeather.like_count + 1))
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(String(seoulWithWeather.dislike_count - 1))
+      ).toBeInTheDocument();
+    });
+    const likeBtn = screen.getByRole("button", { name: "👍" });
+    const dislikeBtn = screen.getByRole("button", { name: "👎" });
+    expect(likeBtn.className).toMatch(/text-blue-600/);
+    expect(dislikeBtn.className).not.toMatch(/text-red-600/);
   });
 
   it("renders the tag-like metadata: budget, area, environment (joined), and best_season (joined)", () => {

--- a/app/src/components/sections/city-card.tsx
+++ b/app/src/components/sections/city-card.tsx
@@ -27,9 +27,13 @@ export function CityCard({
   );
 
   function send(direction: VoteDirection, serverDirection: VoteDirection) {
-    startTransition(() => {
+    // Awaiting the action inside startTransition keeps the transition
+    // "pending" long enough for useOptimistic to surface the mutated state.
+    // Without the await the callback returns synchronously, the action is
+    // considered settled, and the optimistic counters never appear on screen.
+    startTransition(async () => {
       mutate(direction);
-      voteCity(city.id, serverDirection);
+      await voteCity(city.id, serverDirection);
     });
   }
 

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,15 +1,14 @@
 import { defineConfig } from "vitest/config";
 import path from "node:path";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
   resolve: {
+    // Vite 7+ resolves tsconfig `paths` natively; no plugin needed.
+    tsconfigPaths: true,
     alias: {
-      // TODO(test-setup): `server-only` is Next.js' client-component guard. Under
-      // Vitest we need to alias it to an empty stub so modules that `import
-      // "server-only"` (lib/queries.ts, lib/current-user.ts, app/actions/*)
-      // can load. Remove this alias once the setup branch adds a shared stub.
+      // `server-only` is Next.js' RSC-guard marker. Point it at an empty
+      // stub so modules that `import "server-only"` (lib/queries.ts,
+      // lib/current-user.ts, app/actions/*) can be loaded under Vitest.
       "server-only": path.resolve(__dirname, "./test/stubs/server-only.ts"),
     },
   },


### PR DESCRIPTION
## Summary
Two small follow-ups flagged in PR #12:

1. **CityCard optimistic vote fix** — React 19's \`useOptimistic\` only keeps the mutated value while the enclosing action is pending. The old \`startTransition(() => { mutate(d); voteCity(...) })\` callback returned synchronously, so the action was considered done in the same tick and the optimistic counter never rendered. Wrap the transition in \`async\` and \`await\` the server-action promise so the optimistic state sticks.
2. **Drop \`vite-tsconfig-paths\`** — Vite 7 / Vitest 4.1 resolve tsconfig \`paths\` natively via \`resolve.tsconfigPaths: true\`. The plugin was emitting a deprecation warning on every run; replacing it removes one dependency and one warning.

## Commits
- \`fix(city-card): await voteCity in startTransition so optimistic state holds\`
- \`chore(test): drop vite-tsconfig-paths in favor of Vite's native support\`

## Test additions
\`city-card.test.tsx\` gains three specs that now actually pass because the fix makes the optimistic render observable:
- none→like: click 👍 → count +1 + \`text-blue-600\` on the button.
- like→clear: click 👍 while already liked → count -1 + active style cleared.
- dislike→like: count swap (+1 / -1) and active styles swap accordingly.

Each test uses \`voteCityMock.mockReturnValueOnce(new Promise(() => {}))\` so the action stays pending for the assertion window.

## Validation
- \`npm test\` → 15 files / **135 passed** (was 132; +3 optimistic tests).
- \`npx next build\` → clean.
- Deprecation warning about \`vite-tsconfig-paths\` no longer appears.

## Test plan
- [ ] \`cd app && npm test\`
- [ ] \`cd app && npx next build\`
- [ ] Manually toggle 👍/👎 on a city card: counter should flip immediately and stay flipped while the Supabase round-trip is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)